### PR TITLE
Add system: prefix to absolute asset paths

### DIFF
--- a/crates/mod-host-assets/src/mapping.rs
+++ b/crates/mod-host-assets/src/mapping.rs
@@ -1,8 +1,10 @@
 use std::{
     collections::{HashMap, VecDeque},
+    ffi::OsString,
     fs::read_dir,
     os::windows::ffi::OsStrExt,
     path::{Path, PathBuf, StripPrefixError},
+    str::FromStr,
 };
 
 use me3_mod_protocol::package::AssetOverrideSource;
@@ -66,11 +68,11 @@ impl ArchiveOverrideMapping {
                 } else {
                     let override_path = normalize_path(dir_entry);
                     let vfs_path = path_to_asset_lookup_key(&base_directory, &override_path)?;
+                    let mut override_value = OsString::from_str("system:").unwrap();
+                    override_value.push(override_path.as_os_str());
 
-                    self.map.insert(
-                        vfs_path,
-                        override_path.into_os_string().encode_wide().collect(),
-                    );
+                    self.map
+                        .insert(vfs_path, override_value.encode_wide().collect());
                 }
             }
         }

--- a/crates/mod-host/src/asset_archive.rs
+++ b/crates/mod-host/src/asset_archive.rs
@@ -47,6 +47,9 @@ pub fn attach(
                 debug!("Supplied override: {resource_path_string} -> {}", unsafe {
                     get_dlwstring_contents(path.as_ref().unwrap())
                 });
+
+                // Re-execut path normalization since we returned a system: prefix
+                (ctx.trampoline)(path, p2, p3, p4, p5, p6);
             }
         })
         .install()?;


### PR DESCRIPTION
Previously these paths were relative which presumably worked fine when returned directly from the asset override hook, that's what we did in ME2 and it worked fine because we caught that relative path in a `CreateFile` hook.

Attempt to avoid that here by using the `system:` storage device notation supported in FS games.