### PR TITLE
Model DLString with cxx-stl and remove cxx dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,17 +377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "codespan-reporting"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstl-sys"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f649cfeee5615f2422ac1d2bcd08ddc2e57b8e51a0a60cec3b6af88326fa74"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cstr"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,62 +501,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.158"
+name = "cxx-stl"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71ea7f29c73f7ffa64c50b83c9fe4d3a6d4be89a86b009eb80d5a6d3429d741"
+checksum = "5c954d474a5def48b7ef73af5e05141ece320f93c7ce2fb330254ede785eb219"
 dependencies = [
- "cc",
- "cxxbridge-cmd",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "foldhash",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.158"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a8232661d66dcf713394726157d3cfe0a89bfc85f52d6e9f9bbc2306797fe7"
-dependencies = [
- "cc",
- "codespan-reporting",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "cxxbridge-cmd"
-version = "1.0.158"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f44296c8693e9ea226a48f6a122727f77aa9e9e338380cb021accaeeb7ee279"
-dependencies = [
- "clap",
- "codespan-reporting",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.158"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f69c181c176981ae44ba9876e2ea41ce8e574c296b38d06925ce9214fb8e4"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.158"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8faff5d4467e0709448187df29ccbf3b0982cc426ee444a193f87b11afb565a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
+ "cstl-sys",
 ]
 
 [[package]]
@@ -1276,15 +1224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,8 +1354,7 @@ dependencies = [
 name = "me3-mod-host-assets"
 version = "0.2.0"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cxx-stl",
  "me3-mod-protocol",
  "thiserror 2.0.12",
  "tracing",
@@ -2213,12 +2151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scratch"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
-
-[[package]]
 name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,15 +2610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,12 +2952,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -7,13 +7,10 @@ license.workspace = true
 description = "Override game assets with local versions"
 
 [dependencies]
-cxx = { version = "1.0", features = ["c++17"] }
+cxx-stl = { version = "3", features = ["msvc2012"] }
 thiserror.workspace = true
 me3-mod-protocol.workspace = true
 tracing.workspace = true
-
-[build-dependencies]
-cxx-build = "1.0"
 
 [lints]
 workspace = true

--- a/crates/mod-host-assets/build.rs
+++ b/crates/mod-host-assets/build.rs
@@ -1,9 +1,0 @@
-fn main() {
-    cxx_build::bridge("src/lib.rs")
-        .include("include")
-        .compile("test");
-
-    println!("cargo:rerun-if-changed=src/lib.rs");
-    println!("cargo:rerun-if-changed=include/dl_allocator.hpp");
-    println!("cargo:rerun-if-changed=include/dl_string_bridge.hpp");
-}

--- a/crates/mod-host-assets/src/alloc.rs
+++ b/crates/mod-host-assets/src/alloc.rs
@@ -1,0 +1,126 @@
+//! `DLKR::DLAllocator` layout and compatible allocator for use in place of [`DLStdAllocator`]
+//! from the `Dantelion2` in-house FromSoftware library.
+
+use std::{
+    alloc::{GlobalAlloc, Layout},
+    mem::ManuallyDrop,
+    ptr::NonNull,
+};
+
+/// Commonly used polymorphic `DLAllocator` adapter for objects and containers.
+///
+/// Contains a pointer to a `DLAllocator` interface and implements [`GlobalAlloc`].
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct DLStdAllocator {
+    inner: NonNull<DLAllocator>,
+}
+
+#[repr(C)]
+struct DLAllocator {
+    vtable: NonNull<DLAllocatorVtable>,
+}
+
+#[repr(u32)]
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Default)]
+enum DLHeapDirection {
+    #[default]
+    Front = 0,
+    Back = 1,
+}
+
+#[repr(C)]
+struct DLAllocatorVtable {
+    dtor: extern "C" fn(this: NonNull<ManuallyDrop<DLAllocator>>),
+
+    heap_id: extern "C" fn(this: NonNull<DLAllocator>) -> u32,
+
+    allocator_id: extern "C" fn(this: NonNull<DLAllocator>) -> u32,
+
+    capability: extern "C" fn(
+        this: NonNull<DLAllocator>,
+        out: NonNull<u32>,
+        heap: DLHeapDirection,
+    ) -> NonNull<u32>,
+
+    total_size: extern "C" fn(this: NonNull<DLAllocator>) -> usize,
+
+    free_size: extern "C" fn(this: NonNull<DLAllocator>) -> usize,
+
+    max_size: extern "C" fn(this: NonNull<DLAllocator>) -> usize,
+
+    num_blocks: extern "C" fn(this: NonNull<DLAllocator>) -> usize,
+
+    block_size: extern "C" fn(this: NonNull<DLAllocator>, block: *mut u8) -> usize,
+
+    allocate: extern "C" fn(this: NonNull<DLAllocator>, size: usize) -> *mut u8,
+
+    allocate_aligned:
+        extern "C" fn(this: NonNull<DLAllocator>, size: usize, alignment: usize) -> *mut u8,
+
+    reallocate: extern "C" fn(this: NonNull<DLAllocator>, old: *mut u8, new_size: usize) -> *mut u8,
+
+    reallocate_aligned: extern "C" fn(
+        this: NonNull<DLAllocator>,
+        old: *mut u8,
+        new_size: usize,
+        alignment: usize,
+    ) -> *mut u8,
+
+    free: extern "C" fn(this: NonNull<DLAllocator>, ptr: *mut u8),
+
+    free_all: extern "C" fn(this: NonNull<DLAllocator>),
+
+    back_allocate: extern "C" fn(this: NonNull<DLAllocator>, size: usize) -> *mut u8,
+
+    back_allocate_aligned:
+        extern "C" fn(this: NonNull<DLAllocator>, size: usize, alignment: usize) -> *mut u8,
+
+    back_reallocate:
+        extern "C" fn(this: NonNull<DLAllocator>, old: *mut u8, new_size: usize) -> *mut u8,
+
+    back_reallocate_aligned: extern "C" fn(
+        this: NonNull<DLAllocator>,
+        old: *mut u8,
+        new_size: usize,
+        alignment: usize,
+    ) -> *mut u8,
+
+    back_free: extern "C" fn(this: NonNull<DLAllocator>, ptr: *mut u8),
+
+    self_diagnose: extern "C" fn(this: NonNull<DLAllocator>) -> bool,
+
+    is_valid_block: extern "C" fn(this: NonNull<DLAllocator>, block: *mut u8) -> bool,
+
+    lock: extern "C" fn(this: NonNull<DLAllocator>),
+
+    unlock: extern "C" fn(this: NonNull<DLAllocator>),
+
+    block_of: extern "C" fn(this: NonNull<DLAllocator>, ptr: *mut u8) -> *mut u8,
+}
+
+unsafe impl GlobalAlloc for DLStdAllocator {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let size = layout.size();
+        let alignment = layout.align();
+
+        let vtable = unsafe { self.inner.as_ref().vtable.as_ref() };
+        (vtable.allocate_aligned)(self.inner, size, alignment)
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {
+        let vtable = unsafe { self.inner.as_ref().vtable.as_ref() };
+        (vtable.free)(self.inner, ptr);
+    }
+}
+
+unsafe impl Send for DLAllocator {}
+
+unsafe impl Sync for DLAllocator {}
+
+unsafe impl Send for DLStdAllocator {}
+
+unsafe impl Sync for DLStdAllocator {}

--- a/crates/mod-host-assets/src/alloc.rs
+++ b/crates/mod-host-assets/src/alloc.rs
@@ -1,4 +1,4 @@
-//! `DLKR::DLAllocator` layout and compatible allocator for use in place of [`DLStdAllocator`]
+//! `DLKR::DlAllocator` layout and compatible allocator for use in place of [`DlStdAllocator`]
 //! from the `Dantelion2` in-house FromSoftware library.
 
 use std::{
@@ -7,100 +7,100 @@ use std::{
     ptr::NonNull,
 };
 
-/// Commonly used polymorphic `DLAllocator` adapter for objects and containers.
+/// Commonly used polymorphic `DlAllocator` adapter for objects and containers.
 ///
-/// Contains a pointer to a `DLAllocator` interface and implements [`GlobalAlloc`].
+/// Contains a pointer to a `DlAllocator` interface and implements [`GlobalAlloc`].
 #[repr(C)]
 #[derive(Clone, Debug)]
-pub struct DLStdAllocator {
-    inner: NonNull<DLAllocator>,
+pub struct DlStdAllocator {
+    inner: NonNull<DlAllocator>,
 }
 
 #[repr(C)]
-struct DLAllocator {
-    vtable: NonNull<DLAllocatorVtable>,
+struct DlAllocator {
+    vtable: NonNull<DlAllocatorVtable>,
 }
 
 #[repr(u32)]
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default)]
-enum DLHeapDirection {
+enum DlHeapDirection {
     #[default]
     Front = 0,
     Back = 1,
 }
 
 #[repr(C)]
-struct DLAllocatorVtable {
-    dtor: extern "C" fn(this: NonNull<ManuallyDrop<DLAllocator>>),
+struct DlAllocatorVtable {
+    dtor: extern "C" fn(this: NonNull<ManuallyDrop<DlAllocator>>),
 
-    heap_id: extern "C" fn(this: NonNull<DLAllocator>) -> u32,
+    heap_id: extern "C" fn(this: NonNull<DlAllocator>) -> u32,
 
-    allocator_id: extern "C" fn(this: NonNull<DLAllocator>) -> u32,
+    allocator_id: extern "C" fn(this: NonNull<DlAllocator>) -> u32,
 
     capability: extern "C" fn(
-        this: NonNull<DLAllocator>,
+        this: NonNull<DlAllocator>,
         out: NonNull<u32>,
-        heap: DLHeapDirection,
+        heap: DlHeapDirection,
     ) -> NonNull<u32>,
 
-    total_size: extern "C" fn(this: NonNull<DLAllocator>) -> usize,
+    total_size: extern "C" fn(this: NonNull<DlAllocator>) -> usize,
 
-    free_size: extern "C" fn(this: NonNull<DLAllocator>) -> usize,
+    free_size: extern "C" fn(this: NonNull<DlAllocator>) -> usize,
 
-    max_size: extern "C" fn(this: NonNull<DLAllocator>) -> usize,
+    max_size: extern "C" fn(this: NonNull<DlAllocator>) -> usize,
 
-    num_blocks: extern "C" fn(this: NonNull<DLAllocator>) -> usize,
+    num_blocks: extern "C" fn(this: NonNull<DlAllocator>) -> usize,
 
-    block_size: extern "C" fn(this: NonNull<DLAllocator>, block: *mut u8) -> usize,
+    block_size: extern "C" fn(this: NonNull<DlAllocator>, block: *mut u8) -> usize,
 
-    allocate: extern "C" fn(this: NonNull<DLAllocator>, size: usize) -> *mut u8,
+    allocate: extern "C" fn(this: NonNull<DlAllocator>, size: usize) -> *mut u8,
 
     allocate_aligned:
-        extern "C" fn(this: NonNull<DLAllocator>, size: usize, alignment: usize) -> *mut u8,
+        extern "C" fn(this: NonNull<DlAllocator>, size: usize, alignment: usize) -> *mut u8,
 
-    reallocate: extern "C" fn(this: NonNull<DLAllocator>, old: *mut u8, new_size: usize) -> *mut u8,
+    reallocate: extern "C" fn(this: NonNull<DlAllocator>, old: *mut u8, new_size: usize) -> *mut u8,
 
     reallocate_aligned: extern "C" fn(
-        this: NonNull<DLAllocator>,
+        this: NonNull<DlAllocator>,
         old: *mut u8,
         new_size: usize,
         alignment: usize,
     ) -> *mut u8,
 
-    free: extern "C" fn(this: NonNull<DLAllocator>, ptr: *mut u8),
+    free: extern "C" fn(this: NonNull<DlAllocator>, ptr: *mut u8),
 
-    free_all: extern "C" fn(this: NonNull<DLAllocator>),
+    free_all: extern "C" fn(this: NonNull<DlAllocator>),
 
-    back_allocate: extern "C" fn(this: NonNull<DLAllocator>, size: usize) -> *mut u8,
+    back_allocate: extern "C" fn(this: NonNull<DlAllocator>, size: usize) -> *mut u8,
 
     back_allocate_aligned:
-        extern "C" fn(this: NonNull<DLAllocator>, size: usize, alignment: usize) -> *mut u8,
+        extern "C" fn(this: NonNull<DlAllocator>, size: usize, alignment: usize) -> *mut u8,
 
     back_reallocate:
-        extern "C" fn(this: NonNull<DLAllocator>, old: *mut u8, new_size: usize) -> *mut u8,
+        extern "C" fn(this: NonNull<DlAllocator>, old: *mut u8, new_size: usize) -> *mut u8,
 
     back_reallocate_aligned: extern "C" fn(
-        this: NonNull<DLAllocator>,
+        this: NonNull<DlAllocator>,
         old: *mut u8,
         new_size: usize,
         alignment: usize,
     ) -> *mut u8,
 
-    back_free: extern "C" fn(this: NonNull<DLAllocator>, ptr: *mut u8),
+    back_free: extern "C" fn(this: NonNull<DlAllocator>, ptr: *mut u8),
 
-    self_diagnose: extern "C" fn(this: NonNull<DLAllocator>) -> bool,
+    self_diagnose: extern "C" fn(this: NonNull<DlAllocator>) -> bool,
 
-    is_valid_block: extern "C" fn(this: NonNull<DLAllocator>, block: *mut u8) -> bool,
+    is_valid_block: extern "C" fn(this: NonNull<DlAllocator>, block: *mut u8) -> bool,
 
-    lock: extern "C" fn(this: NonNull<DLAllocator>),
+    lock: extern "C" fn(this: NonNull<DlAllocator>),
 
-    unlock: extern "C" fn(this: NonNull<DLAllocator>),
+    unlock: extern "C" fn(this: NonNull<DlAllocator>),
 
-    block_of: extern "C" fn(this: NonNull<DLAllocator>, ptr: *mut u8) -> *mut u8,
+    block_of: extern "C" fn(this: NonNull<DlAllocator>, ptr: *mut u8) -> *mut u8,
 }
 
-unsafe impl GlobalAlloc for DLStdAllocator {
+unsafe impl GlobalAlloc for DlStdAllocator {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let size = layout.size();
@@ -117,10 +117,10 @@ unsafe impl GlobalAlloc for DLStdAllocator {
     }
 }
 
-unsafe impl Send for DLAllocator {}
+unsafe impl Send for DlAllocator {}
 
-unsafe impl Sync for DLAllocator {}
+unsafe impl Sync for DlAllocator {}
 
-unsafe impl Send for DLStdAllocator {}
+unsafe impl Send for DlStdAllocator {}
 
-unsafe impl Sync for DLStdAllocator {}
+unsafe impl Sync for DlStdAllocator {}

--- a/crates/mod-host-assets/src/lib.rs
+++ b/crates/mod-host-assets/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod alloc;
 pub mod mapping;
 pub mod rva;
+pub mod string;
 pub mod wwise;
 
 #[cxx::bridge]

--- a/crates/mod-host-assets/src/lib.rs
+++ b/crates/mod-host-assets/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alloc;
 pub mod mapping;
 pub mod rva;
 pub mod wwise;

--- a/crates/mod-host-assets/src/lib.rs
+++ b/crates/mod-host-assets/src/lib.rs
@@ -3,15 +3,3 @@ pub mod mapping;
 pub mod rva;
 pub mod string;
 pub mod wwise;
-
-#[cxx::bridge]
-pub mod ffi {
-    unsafe extern "C++" {
-        include!("dl_string_bridge.hpp");
-
-        pub type DLWString;
-
-        pub fn get_dlwstring_contents(string: &DLWString) -> String;
-        pub fn set_dlwstring_contents(string: &DLWString, contents: &[u16]);
-    }
-}

--- a/crates/mod-host-assets/src/string.rs
+++ b/crates/mod-host-assets/src/string.rs
@@ -1,0 +1,148 @@
+//! DLBasicString with additional type checking using the provided encoding
+//! discriminator.
+//!
+//! [`DLString`] instances can be read and written from existing structures, but not created.
+//!
+//! [`DLHashString`] instances cache its DLHash 32-bit hash using interior mutability.
+//!
+//! Thanks to Axi! for finding out the possible encoding tags.
+
+use cxx_stl::{
+    alloc::CxxProxy,
+    string::{CxxNarrowString, CxxUtf16String, CxxUtf32String, CxxUtf8String},
+};
+use thiserror::Error;
+
+#[repr(u8)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug)]
+pub enum DLStringEncoding {
+    UTF8 = encoding::UTF8,
+    UTF16 = encoding::UTF16,
+    ISO_8859 = encoding::ISO_8859,
+    SJIS = encoding::SJIS,
+    EUC_JP = encoding::EUC_JP,
+    UTF32 = encoding::UTF32,
+}
+
+pub type DLStringUtf8<A> = DLString<CxxUtf8String<A>, { encoding::UTF8 }>;
+
+pub type DLStringUtf16<A> = DLString<CxxUtf16String<A>, { encoding::UTF16 }>;
+
+pub type DLStringIso8859<A> = DLString<CxxNarrowString<A>, { encoding::ISO_8859 }>;
+
+pub type DLStringSjis<A> = DLString<CxxNarrowString<A>, { encoding::SJIS }>;
+
+pub type DLStringEucJP<A> = DLString<CxxNarrowString<A>, { encoding::EUC_JP }>;
+
+pub type DLStringUtf32<A> = DLString<CxxUtf32String<A>, { encoding::UTF32 }>;
+
+#[derive(Clone)]
+pub struct DLString<T, const E: u8> {
+    inner: T,
+    encoding: u8,
+}
+
+impl<T, const E: u8> DLString<T, E> {
+    pub fn encoding(
+        &self,
+    ) -> Result<DLStringEncoding, <DLStringEncoding as TryFrom<u8>>::Error> {
+        self.encoding.try_into()
+    }
+
+    pub fn get(&self) -> Result<&T, EncodingError> {
+        if self.encoding == E {
+            Ok(&self.inner)
+        } else {
+            Err(EncodingError::new(Self::EXPECTED, self.encoding))
+        }
+    }
+
+    pub fn get_mut(&mut self) -> Result<&mut T, EncodingError> {
+        if self.encoding == E {
+            Ok(&mut self.inner)
+        } else {
+            Err(EncodingError::new(Self::EXPECTED, self.encoding))
+        }
+    }
+
+    pub unsafe fn get_unchecked(&self) -> &T {
+        &self.inner
+    }
+
+    pub unsafe fn get_unchecked_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    const EXPECTED: DLStringEncoding = match DLStringEncoding::from_raw(E) {
+        Ok(encoding) => encoding,
+        Err(_undefined) => panic!("encoding not defined"),
+    };
+}
+
+#[cfg(windows)]
+impl<A: CxxProxy> DLStringUtf16<A> {
+    pub fn decode(&self) -> Result<String, EncodingError> {
+        use std::{ffi::OsString, os::windows::ffi::OsStringExt};
+
+        Ok(OsString::from_wide(self.get()?.as_bytes())
+            .to_string_lossy()
+            .into_owned())
+    }
+
+    pub fn encode<T: AsRef<str>>(&mut self, s: T) -> Result<(), EncodingError> {
+        let inner = self.get_mut()?;
+
+        inner.clear();
+        inner.extend(s.as_ref().encode_utf16());
+
+        Ok(())
+    }
+}
+
+#[derive(Error, Debug)]
+#[error(
+    "DLString encoding error; expected {:?} but got {:?}",
+    expected, DLStringEncoding::try_from(*actual)
+)]
+pub struct EncodingError {
+    expected: DLStringEncoding,
+    actual: u8,
+}
+
+impl EncodingError {
+    const fn new(expected: DLStringEncoding, actual: u8) -> Self {
+        Self { expected, actual }
+    }
+}
+
+impl DLStringEncoding {
+    const fn from_raw(value: u8) -> Result<Self, u8> {
+        match value {
+            encoding::UTF8 => Ok(DLStringEncoding::UTF8),
+            encoding::UTF16 => Ok(DLStringEncoding::UTF16),
+            encoding::ISO_8859 => Ok(DLStringEncoding::ISO_8859),
+            encoding::SJIS => Ok(DLStringEncoding::SJIS),
+            encoding::EUC_JP => Ok(DLStringEncoding::EUC_JP),
+            encoding::UTF32 => Ok(DLStringEncoding::UTF32),
+            value => Err(value),
+        }
+    }
+}
+
+impl TryFrom<u8> for DLStringEncoding {
+    type Error = u8;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Self::from_raw(value)
+    }
+}
+
+pub mod encoding {
+    pub const UTF8: u8 = 0;
+    pub const UTF16: u8 = 1;
+    pub const ISO_8859: u8 = 2;
+    pub const SJIS: u8 = 3;
+    pub const EUC_JP: u8 = 4;
+    pub const UTF32: u8 = 5;
+}

--- a/crates/mod-host-assets/src/string.rs
+++ b/crates/mod-host-assets/src/string.rs
@@ -51,9 +51,7 @@ pub struct DLString<T, const E: u8> {
 }
 
 impl<T, const E: u8> DLString<T, E> {
-    pub fn encoding(
-        &self,
-    ) -> Result<DLStringEncoding, <DLStringEncoding as TryFrom<u8>>::Error> {
+    pub fn encoding(&self) -> Result<DLStringEncoding, <DLStringEncoding as TryFrom<u8>>::Error> {
         self.encoding.try_into()
     }
 

--- a/crates/mod-host-assets/src/string.rs
+++ b/crates/mod-host-assets/src/string.rs
@@ -13,29 +13,36 @@ use cxx_stl::{
 };
 use thiserror::Error;
 
+const UTF8: u8 = 0;
+const UTF16: u8 = 1;
+const ISO_8859: u8 = 2;
+const SJIS: u8 = 3;
+const EUC_JP: u8 = 4;
+const UTF32: u8 = 5;
+
 #[repr(u8)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]
 pub enum DLStringEncoding {
-    UTF8 = encoding::UTF8,
-    UTF16 = encoding::UTF16,
-    ISO_8859 = encoding::ISO_8859,
-    SJIS = encoding::SJIS,
-    EUC_JP = encoding::EUC_JP,
-    UTF32 = encoding::UTF32,
+    UTF8 = UTF8,
+    UTF16 = UTF16,
+    ISO_8859 = ISO_8859,
+    SJIS = SJIS,
+    EUC_JP = EUC_JP,
+    UTF32 = UTF32,
 }
 
-pub type DLStringUtf8<A> = DLString<CxxUtf8String<A>, { encoding::UTF8 }>;
+pub type DLStringUtf8<A> = DLString<CxxUtf8String<A>, { UTF8 }>;
 
-pub type DLStringUtf16<A> = DLString<CxxUtf16String<A>, { encoding::UTF16 }>;
+pub type DLStringUtf16<A> = DLString<CxxUtf16String<A>, { UTF16 }>;
 
-pub type DLStringIso8859<A> = DLString<CxxNarrowString<A>, { encoding::ISO_8859 }>;
+pub type DLStringIso8859<A> = DLString<CxxNarrowString<A>, { ISO_8859 }>;
 
-pub type DLStringSjis<A> = DLString<CxxNarrowString<A>, { encoding::SJIS }>;
+pub type DLStringSjis<A> = DLString<CxxNarrowString<A>, { SJIS }>;
 
-pub type DLStringEucJP<A> = DLString<CxxNarrowString<A>, { encoding::EUC_JP }>;
+pub type DLStringEucJP<A> = DLString<CxxNarrowString<A>, { EUC_JP }>;
 
-pub type DLStringUtf32<A> = DLString<CxxUtf32String<A>, { encoding::UTF32 }>;
+pub type DLStringUtf32<A> = DLString<CxxUtf32String<A>, { UTF32 }>;
 
 #[derive(Clone)]
 pub struct DLString<T, const E: u8> {
@@ -119,12 +126,12 @@ impl EncodingError {
 impl DLStringEncoding {
     const fn from_raw(value: u8) -> Result<Self, u8> {
         match value {
-            encoding::UTF8 => Ok(DLStringEncoding::UTF8),
-            encoding::UTF16 => Ok(DLStringEncoding::UTF16),
-            encoding::ISO_8859 => Ok(DLStringEncoding::ISO_8859),
-            encoding::SJIS => Ok(DLStringEncoding::SJIS),
-            encoding::EUC_JP => Ok(DLStringEncoding::EUC_JP),
-            encoding::UTF32 => Ok(DLStringEncoding::UTF32),
+            UTF8 => Ok(DLStringEncoding::UTF8),
+            UTF16 => Ok(DLStringEncoding::UTF16),
+            ISO_8859 => Ok(DLStringEncoding::ISO_8859),
+            SJIS => Ok(DLStringEncoding::SJIS),
+            EUC_JP => Ok(DLStringEncoding::EUC_JP),
+            UTF32 => Ok(DLStringEncoding::UTF32),
             value => Err(value),
         }
     }
@@ -136,13 +143,4 @@ impl TryFrom<u8> for DLStringEncoding {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         Self::from_raw(value)
     }
-}
-
-pub mod encoding {
-    pub const UTF8: u8 = 0;
-    pub const UTF16: u8 = 1;
-    pub const ISO_8859: u8 = 2;
-    pub const SJIS: u8 = 3;
-    pub const EUC_JP: u8 = 4;
-    pub const UTF32: u8 = 5;
 }

--- a/crates/mod-host-assets/src/string.rs
+++ b/crates/mod-host-assets/src/string.rs
@@ -158,26 +158,24 @@ impl<T, const E: u8> DerefMut for TrustedDlString<T, E> {
     }
 }
 
-impl<A: CxxProxy> ToString for TrustedDlString<CxxUtf8String<A>, { UTF8 }> {
-    fn to_string(&self) -> String {
+impl<A: CxxProxy> fmt::Display for TrustedDlString<CxxUtf8String<A>, { UTF8 }> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // SAFETY: `self` is encoded at least as a UTF-8 superset
         // as verified by checking the encoding.
-        unsafe {
-            OsStr::from_encoded_bytes_unchecked(self.as_bytes())
-                .to_string_lossy()
-                .into_owned()
-        }
+        let os_str = unsafe { OsStr::from_encoded_bytes_unchecked(self.as_bytes()) };
+
+        f.write_str(&os_str.to_string_lossy())
     }
 }
 
 #[cfg(windows)]
-impl<A: CxxProxy> ToString for TrustedDlString<CxxUtf16String<A>, { UTF16 }> {
-    fn to_string(&self) -> String {
+impl<A: CxxProxy> fmt::Display for TrustedDlString<CxxUtf16String<A>, { UTF16 }> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
-        OsString::from_wide(self.as_bytes())
-            .to_string_lossy()
-            .into_owned()
+        let os_str = OsString::from_wide(self.as_bytes());
+
+        f.write_str(&os_str.to_string_lossy())
     }
 }
 

--- a/crates/mod-host-assets/src/string.rs
+++ b/crates/mod-host-assets/src/string.rs
@@ -1,17 +1,26 @@
 //! DLBasicString with additional type checking using the provided encoding
 //! discriminator.
 //!
-//! [`DLString`] instances can be read and written from existing structures, but not created.
+//! [`DlString`] instances can be read and written from existing structures, but not created.
 //!
 //! [`DLHashString`] instances cache its DLHash 32-bit hash using interior mutability.
 //!
 //! Thanks to Axi! for finding out the possible encoding tags.
+
+use core::fmt;
+use std::{
+    ffi::OsStr,
+    mem,
+    ops::{Deref, DerefMut},
+};
 
 use cxx_stl::{
     alloc::CxxProxy,
     string::{CxxNarrowString, CxxUtf16String, CxxUtf32String, CxxUtf8String},
 };
 use thiserror::Error;
+
+use crate::alloc::DlStdAllocator;
 
 const UTF8: u8 = 0;
 const UTF16: u8 = 1;
@@ -21,124 +30,162 @@ const EUC_JP: u8 = 4;
 const UTF32: u8 = 5;
 
 #[repr(u8)]
-#[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]
-pub enum DLStringEncoding {
-    UTF8 = UTF8,
-    UTF16 = UTF16,
-    ISO_8859 = ISO_8859,
-    SJIS = SJIS,
-    EUC_JP = EUC_JP,
-    UTF32 = UTF32,
+pub enum DlCharacterSet {
+    Utf8 = UTF8,
+    Utf16 = UTF16,
+    Iso8859 = ISO_8859,
+    ShiftJis = SJIS,
+    EucJp = EUC_JP,
+    Utf32 = UTF32,
 }
 
-pub type DLStringUtf8<A> = DLString<CxxUtf8String<A>, { UTF8 }>;
+pub type DlUtf8String<A = DlStdAllocator> = DlString<CxxUtf8String<A>, { UTF8 }>;
 
-pub type DLStringUtf16<A> = DLString<CxxUtf16String<A>, { UTF16 }>;
+pub type DlUtf16String<A = DlStdAllocator> = DlString<CxxUtf16String<A>, { UTF16 }>;
 
-pub type DLStringIso8859<A> = DLString<CxxNarrowString<A>, { ISO_8859 }>;
+pub type DlIso8859String<A = DlStdAllocator> = DlString<CxxNarrowString<A>, { ISO_8859 }>;
 
-pub type DLStringSjis<A> = DLString<CxxNarrowString<A>, { SJIS }>;
+pub type DlSjisString<A = DlStdAllocator> = DlString<CxxNarrowString<A>, { SJIS }>;
 
-pub type DLStringEucJP<A> = DLString<CxxNarrowString<A>, { EUC_JP }>;
+pub type DlEucJpString<A = DlStdAllocator> = DlString<CxxNarrowString<A>, { EUC_JP }>;
 
-pub type DLStringUtf32<A> = DLString<CxxUtf32String<A>, { UTF32 }>;
+pub type DlUtf32String<A = DlStdAllocator> = DlString<CxxUtf32String<A>, { UTF32 }>;
 
+#[repr(C)]
 #[derive(Clone)]
-pub struct DLString<T, const E: u8> {
+pub struct DlString<T, const E: u8> {
     inner: T,
     encoding: u8,
 }
 
-impl<T, const E: u8> DLString<T, E> {
-    pub fn encoding(&self) -> Result<DLStringEncoding, <DLStringEncoding as TryFrom<u8>>::Error> {
+#[repr(transparent)]
+#[derive(Clone, Debug)]
+pub struct TrustedDlString<T, const E: u8>(DlString<T, E>);
+
+impl<T, const E: u8> DlString<T, E> {
+    pub fn encoding(&self) -> Result<DlCharacterSet, <DlCharacterSet as TryFrom<u8>>::Error> {
         self.encoding.try_into()
     }
 
-    pub fn get(&self) -> Result<&T, EncodingError> {
+    pub fn get(&self) -> Result<&TrustedDlString<T, E>, EncodingError> {
         if self.encoding == E {
-            Ok(&self.inner)
+            // SAFETY: transmuting into transparent wrapper.
+            unsafe { Ok(mem::transmute(self)) }
         } else {
             Err(EncodingError::new(Self::EXPECTED, self.encoding))
         }
     }
 
-    pub fn get_mut(&mut self) -> Result<&mut T, EncodingError> {
+    pub fn get_mut(&mut self) -> Result<&mut TrustedDlString<T, E>, EncodingError> {
         if self.encoding == E {
-            Ok(&mut self.inner)
+            // SAFETY: transmuting into transparent wrapper.
+            unsafe { Ok(mem::transmute(self)) }
         } else {
             Err(EncodingError::new(Self::EXPECTED, self.encoding))
         }
     }
 
-    pub unsafe fn get_unchecked(&self) -> &T {
-        &self.inner
+    /// # Safety
+    /// Only if the static encoding matches the encoding of `self`.
+    pub unsafe fn get_unchecked(&self) -> &TrustedDlString<T, E> {
+        // SAFETY: transmuting into transparent wrapper.
+        unsafe { mem::transmute(self) }
     }
 
+    /// # Safety
+    /// Only if the static encoding matches the encoding of `self`.
     pub unsafe fn get_unchecked_mut(&mut self) -> &mut T {
-        &mut self.inner
+        // SAFETY: transmuting into transparent wrapper.
+        unsafe { mem::transmute(self) }
     }
 
-    const EXPECTED: DLStringEncoding = match DLStringEncoding::from_raw(E) {
+    const EXPECTED: DlCharacterSet = match DlCharacterSet::from_raw(E) {
         Ok(encoding) => encoding,
         Err(_undefined) => panic!("encoding not defined"),
     };
 }
 
-#[cfg(windows)]
-impl<A: CxxProxy> DLStringUtf16<A> {
-    pub fn decode(&self) -> Result<String, EncodingError> {
-        use std::{ffi::OsString, os::windows::ffi::OsStringExt};
-
-        Ok(OsString::from_wide(self.get()?.as_bytes())
-            .to_string_lossy()
-            .into_owned())
-    }
-
-    pub fn encode<T: AsRef<str>>(&mut self, s: T) -> Result<(), EncodingError> {
-        let inner = self.get_mut()?;
-
-        inner.clear();
-        inner.extend(s.as_ref().encode_utf16());
-
-        Ok(())
-    }
-}
-
 #[derive(Error, Debug)]
 #[error(
-    "DLString encoding error; expected {:?} but got {:?}",
-    expected, DLStringEncoding::try_from(*actual)
+    "DlString encoding error; expected {:?} but got {:?}",
+    expected, DlCharacterSet::try_from(*actual)
 )]
 pub struct EncodingError {
-    expected: DLStringEncoding,
+    expected: DlCharacterSet,
     actual: u8,
 }
 
 impl EncodingError {
-    const fn new(expected: DLStringEncoding, actual: u8) -> Self {
+    const fn new(expected: DlCharacterSet, actual: u8) -> Self {
         Self { expected, actual }
     }
 }
 
-impl DLStringEncoding {
+impl DlCharacterSet {
     const fn from_raw(value: u8) -> Result<Self, u8> {
         match value {
-            UTF8 => Ok(DLStringEncoding::UTF8),
-            UTF16 => Ok(DLStringEncoding::UTF16),
-            ISO_8859 => Ok(DLStringEncoding::ISO_8859),
-            SJIS => Ok(DLStringEncoding::SJIS),
-            EUC_JP => Ok(DLStringEncoding::EUC_JP),
-            UTF32 => Ok(DLStringEncoding::UTF32),
+            UTF8 => Ok(DlCharacterSet::Utf8),
+            UTF16 => Ok(DlCharacterSet::Utf16),
+            ISO_8859 => Ok(DlCharacterSet::Iso8859),
+            SJIS => Ok(DlCharacterSet::ShiftJis),
+            EUC_JP => Ok(DlCharacterSet::EucJp),
+            UTF32 => Ok(DlCharacterSet::Utf32),
             value => Err(value),
         }
     }
 }
 
-impl TryFrom<u8> for DLStringEncoding {
+impl TryFrom<u8> for DlCharacterSet {
     type Error = u8;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         Self::from_raw(value)
+    }
+}
+
+impl<T, const E: u8> Deref for TrustedDlString<T, E> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.inner
+    }
+}
+
+impl<T, const E: u8> DerefMut for TrustedDlString<T, E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0.inner
+    }
+}
+
+impl<A: CxxProxy> ToString for TrustedDlString<CxxUtf8String<A>, { UTF8 }> {
+    fn to_string(&self) -> String {
+        // SAFETY: `self` is encoded at least as a UTF-8 superset
+        // as verified by checking the encoding.
+        unsafe {
+            OsStr::from_encoded_bytes_unchecked(self.as_bytes())
+                .to_string_lossy()
+                .into_owned()
+        }
+    }
+}
+
+#[cfg(windows)]
+impl<A: CxxProxy> ToString for TrustedDlString<CxxUtf16String<A>, { UTF16 }> {
+    fn to_string(&self) -> String {
+        use std::{ffi::OsString, os::windows::ffi::OsStringExt};
+
+        OsString::from_wide(self.as_bytes())
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+impl<T: fmt::Debug, const E: u8> fmt::Debug for DlString<T, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DlString")
+            .field("inner", &self.inner)
+            .field("encoding", &self.encoding())
+            .finish()
     }
 }

--- a/crates/mod-host-assets/src/wwise.rs
+++ b/crates/mod-host-assets/src/wwise.rs
@@ -57,7 +57,7 @@ pub fn find_override<'a>(mapping: &'a ArchiveOverrideMapping, input: &str) -> Op
 fn get_override<'a>(mapping: &'a ArchiveOverrideMapping, input: &str) -> Option<&'a [u16]> {
     for prefix in PREFIXES {
         let prefixed = format!("{prefix}/{input}");
-        if let Some(replacement) = mapping.get_override(&prefixed) {
+        if let Some((_, replacement)) = mapping.get_override(&prefixed) {
             return Some(replacement);
         }
     }

--- a/crates/mod-host/src/asset_archive.rs
+++ b/crates/mod-host/src/asset_archive.rs
@@ -1,10 +1,7 @@
 use std::{ffi::c_void, sync::Arc};
 
 use me3_mod_host_assets::{
-    ffi::{get_dlwstring_contents, set_dlwstring_contents, DLWString},
-    mapping::ArchiveOverrideMapping,
-    rva::{RVA_ASSET_LOOKUP, RVA_WWISE_ASSET_LOOKUP},
-    wwise::{self, AkOpenMode},
+    alloc::DLStdAllocator, mapping::ArchiveOverrideMapping, rva::{RVA_ASSET_LOOKUP, RVA_WWISE_ASSET_LOOKUP}, string::DLStringUtf16, wwise::{self, AkOpenMode}
 };
 use tracing::debug;
 use windows::{
@@ -16,7 +13,7 @@ use crate::host::ModHost;
 
 /// This is a heavily obfuscated std::basic_string replace-esque. It's only
 /// used when the game wants to expand a path as part of the archive lookup.
-pub type ExpandArchivePathFn = extern "C" fn(*mut DLWString, usize, usize, usize, usize, usize);
+pub type ExpandArchivePathFn = extern "C" fn(*mut DLStringUtf16<DLStdAllocator>, usize, usize, usize, usize, usize);
 
 /// This function is part of FS's implementation of IAkLowLevelIOHook.
 pub type WwisePathFn = extern "C" fn(usize, PCWSTR, u64, usize, usize, usize) -> usize;
@@ -31,22 +28,21 @@ pub fn attach(
         .with_closure(move |ctx, path, p2, p3, p4, p5, p6| {
             // Have the game expand the path for us.
             (ctx.trampoline)(path, p2, p3, p4, p5, p6);
-
-            let resource_path_string = get_dlwstring_contents(unsafe { path.as_mut().unwrap() });
+            
+            let path = unsafe { path.as_mut().unwrap() };
+            let resource_path_string = path.decode().unwrap();
 
             debug!("Asset requested: {resource_path_string}");
 
             // Match the expanded path against the known overrides.
-            if let Some(mapped_override) = mapping.get_override(&resource_path_string) {
+            if let Some((mapped_path, mapped_override)) = mapping.get_override(&resource_path_string) {
                 // Replace the string with a canonical path to the asset if
                 // we did find an override. This will cause the game to
                 // pull the files bytes from the file system instead of the
                 // BDTs.
-                set_dlwstring_contents(unsafe { path.as_ref().unwrap() }, mapped_override);
+                path.get_mut().unwrap().replace(mapped_override);
 
-                debug!("Supplied override: {resource_path_string} -> {}", unsafe {
-                    get_dlwstring_contents(path.as_ref().unwrap())
-                });
+                debug!("Supplied override: {resource_path_string} -> {}", mapped_path.display());
             }
         })
         .install()?;


### PR DESCRIPTION
Use cxx-stl to model utf8, 16, 32, sjis and eucjp strings with encoding validation and DLStdAllocator support for resource overrides.