### PR TITLE
Release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [v0.3.0] - 2025-06-02
+
 ### Added
 
 - Linux installer via shell script by @garyttierney
@@ -48,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash handling and host<->launcher log transport by @garyttierney in [#24](https://github.com/garyttierney/me3/issues/24)
 
 <!-- next-url -->
-[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/v0.3.0...HEAD
+[v0.3.0]: https://github.com/assert-rs/predicates-rs/compare/v0.2.0...v0.3.0
 
 [v0.2.0]: https://github.com/assert-rs/predicates-rs/compare/v0.1.0...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "me3-binary-mapper"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "memmap",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crash-context",
  "dll-syringe",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "eyre",
  "me3-mod-protocol",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crash-handler",
  "dll-syringe",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cxx-stl",
  "me3-mod-protocol",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "expect-test",
  "schemars",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "sentry",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/garyttierney/me3"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION

### Added

- Linux installer via shell script by @garyttierney

### Fixes

- Assign default profile-dir when none has been set by @garyttierney\n---
### Create and publish the tag:

```
git tag --sign -a v0.3.0 e45921b2516981b30d842c4e4d7de3c7126a6e56
git push origin v0.3.0
gh release create v0.3.0 --notes-from-tag --verify-tag
git fetch origin main:main
git merge -ff-only --into-name main "release-v0.3.0"
```