### PR TITLE
Rotate old logs on launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +385,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -1262,6 +1291,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "iced-x86"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1724,7 @@ dependencies = [
 name = "me3-cli"
 version = "0.4.0"
 dependencies = [
+ "chrono",
  "clap",
  "color-eyre",
  "config",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 sentry = ["me3_telemetry/sentry"]
 
 [dependencies]
+chrono = "0.4.41"
 clap = { version = "4.5.38", features = ["derive"] }
 color-eyre = { version = "0.6.4" }
 config = "0.15.11"

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -336,7 +336,7 @@ pub fn launch(
         .filter_map(|entry| {
             let entry = entry.ok()?;
             let metadata = entry.metadata().ok()?;
-            if metadata.is_file() {
+            if metadata.is_file() && entry.path().extension().is_some_and(|ext| ext == "log") {
                 Some((metadata.modified().ok()?, entry.path()))
             } else {
                 None

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::{
     env,
+    error::Error,
     fs::{File, OpenOptions},
     path::PathBuf,
     sync::{
@@ -156,7 +157,7 @@ fn run() -> LauncherResult<()> {
                 },
                 Err(IpcError::Disconnected) => break,
                 Err(e) => {
-                    error!("Error from monitor channel {:?}", e);
+                    error!(error = &e as &dyn Error, "Error from monitor channel");
                     break;
                 }
             }
@@ -164,7 +165,7 @@ fn run() -> LauncherResult<()> {
     });
 
     if let Err(e) = game.attach(&args.dll, request) {
-        error!("Failed to attach to game: {e:?}");
+        error!(error = &*e, "Failed to attach to game");
     }
 
     drop(span_guard);


### PR DESCRIPTION
This also restricts the `launch` command to a single profile and uses the profile name as the filename.