### PR TITLE
Release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [v0.4.0] - 2025-06-07
+
 ### Added
 
 - Clean-up old log files and store them in a per-profile directory by @garyttierney in <https://github.com/garyttierney/me3/pull/84>
@@ -57,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash handling and host<->launcher log transport by @garyttierney in [#24](https://github.com/garyttierney/me3/issues/24)
 
 <!-- next-url -->
-[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/assert-rs/predicates-rs/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/assert-rs/predicates-rs/compare/v0.2.0...v0.3.0
 
 [v0.2.0]: https://github.com/assert-rs/predicates-rs/compare/v0.1.0...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "me3-binary-mapper"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "memmap",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crash-context",
  "dll-syringe",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "eyre",
  "me3-mod-protocol",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crash-handler",
  "dll-syringe",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cxx-stl",
  "from-singleton",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "expect-test",
  "schemars",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/garyttierney/me3"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION

### Added

- Clean-up old log files and store them in a per-profile directory by @garyttierney in <https://github.com/garyttierney/me3/pull/84>
- Support overriding files with a game agnostic approach by @Dasaav-dsv in <https://github.com/garyttierney/me3/pull/74>
- Icon for me3 installer and profile files
- Support for running a mod profile with diagnostics enabled by @garyttierney\n---
### Create and publish the tag:

```
./releng/bin/create-release "1113b16c7ca004d9598ee0c61fc12e45d57f1e00"
```