### PR TITLE
Fix `CrashHandler` being uninstalled via its `Drop` impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixes
+
+- Fix mod host crash handler being uninstalled as soon as it was created by @Dasaav-dsv in <https://github.com/garyttierney/me3/pull/91>
+
 ## [v0.4.0] - 2025-06-07
 
 ### Added

--- a/crates/mod-host/src/lib.rs
+++ b/crates/mod-host/src/lib.rs
@@ -4,7 +4,9 @@
 #![feature(unboxed_closures)]
 
 use std::{
-    mem, sync::{Arc, Mutex, OnceLock}, time::Duration
+    mem,
+    sync::{Arc, Mutex, OnceLock},
+    time::Duration,
 };
 
 use crash_handler::CrashEventResult;


### PR DESCRIPTION
The program-wide crash handler for me3_mod_host.dll was dropped as soon as it was assigned. This fix `mem::forget`s its RAII guard.