### PR TITLE
Fix Nightreign file overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Correctly install asset folder in Windows installer by @garyttierney
 - Fix mod host crash handler being uninstalled as soon as it was created by @Dasaav-dsv in <https://github.com/garyttierney/me3/pull/91>
+- Address some file overrides not being loaded in Nightreign by @Dasaav-dsv in <>
 
 ## [v0.4.0] - 2025-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Correctly install asset folder in Windows installer by @garyttierney
 - Fix mod host crash handler being uninstalled as soon as it was created by @Dasaav-dsv in <https://github.com/garyttierney/me3/pull/91>
-- Address some file overrides not being loaded in Nightreign by @Dasaav-dsv in <>
+- Address some file overrides not being loaded in Nightreign by @Dasaav-dsv in <https://github.com/garyttierney/me3/pull/111>
 
 ## [v0.4.0] - 2025-06-07
 

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -299,6 +299,7 @@ pub fn launch(
 
     let attach_config_file = NamedTempFile::new_in(&attach_config_dir)?;
     let attach_config = AttachConfig {
+        game: game.into(),
         packages: ordered_packages,
         natives: ordered_natives,
     };

--- a/crates/launcher-attach-protocol/src/lib.rs
+++ b/crates/launcher-attach-protocol/src/lib.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use me3_mod_protocol::{native::Native, package::Package};
+use me3_mod_protocol::{native::Native, package::Package, Game};
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -12,6 +12,9 @@ pub struct AttachRequest {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AttachConfig {
+    /// The attached to game.
+    pub game: Game,
+
     /// An ordered list of natives to be loaded on attach.
     pub natives: Vec<Native>,
 

--- a/crates/mod-host-assets/src/dl_device.rs
+++ b/crates/mod-host-assets/src/dl_device.rs
@@ -78,6 +78,8 @@ pub struct DlFileOperatorVtable {
     _dtor: usize,
     _copy: usize,
     pub set_path: DlFileOperatorSetPath,
+    pub set_path2: DlFileOperatorSetPath,
+    pub set_path3: DlFileOperatorSetPath,
 }
 
 pub struct BndSnapshot {

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -174,7 +174,7 @@ fn hook_ebl_utility(
             // starting with "sd:" causes an infinite loop trying to resolve the
             // root. Reporting the EBL as having failed to mount prevents it from
             // being added to the lookup list, leaving it empty so that branch not taken.
-            game >= Game::EldenRing && game < Game::Nightreign
+            game < Game::EldenRing || game >= Game::Nightreign
         })
         .install()?;
 

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -174,7 +174,7 @@ fn hook_ebl_utility(
             // starting with "sd:" causes an infinite loop trying to resolve the
             // root. Reporting the EBL as having failed to mount prevents it from
             // being added to the lookup list, leaving it empty so that branch not taken.
-            false
+            game >= Game::EldenRing && game < Game::Nightreign
         })
         .install()?;
 

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -32,7 +32,7 @@ pub fn attach_override(mapping: Arc<ArchiveOverrideMapping>) -> Result<(), eyre:
     let singletons = poll_singletons()?;
 
     debug!(
-        "CSEblFileManager" = ?singletons.get("CSEblFileManager"),
+        "total_singletons" = singletons.len(),
         "singleton initialization passed"
     );
 

--- a/crates/mod-protocol/src/lib.rs
+++ b/crates/mod-protocol/src/lib.rs
@@ -24,13 +24,13 @@ pub enum Game {
     #[serde(rename = "elden-ring")]
     EldenRing,
 
-    #[serde(alias = "nightreign")]
-    #[serde(rename = "nightrein")]
-    Nightreign,
-
     #[serde(rename = "armoredcore6")]
     #[serde(alias = "ac6")]
     ArmoredCore6,
+
+    #[serde(alias = "nightreign")]
+    #[serde(rename = "nightrein")]
+    Nightreign,
 }
 
 #[derive(Debug)]

--- a/crates/mod-protocol/src/lib.rs
+++ b/crates/mod-protocol/src/lib.rs
@@ -16,6 +16,9 @@ pub enum ModProfile {
     V1(ModProfileV1),
 }
 
+/// Chronologically sorted list of games supported by me3.
+///
+/// Feature gates can use [`Ord`] comparisons between game type constants.
 #[derive(
     Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
 )]

--- a/schemas/mod-profile.json
+++ b/schemas/mod-profile.json
@@ -33,11 +33,12 @@
       ]
     },
     "Game": {
+      "description": "Chronologically sorted list of games supported by me3.\n\n Feature gates can use [`Ord`] comparisons between game type constants.",
       "type": "string",
       "enum": [
         "elden-ring",
-        "nightrein",
-        "armoredcore6"
+        "armoredcore6",
+        "nightrein"
       ]
     },
     "ModFile": {


### PR DESCRIPTION
Extend Nightreign support to all non-wwise files by hooking all overloads of the same function instead of the only one used in earlier games.

Get ready to fix missing sound issues when using overrides for Nightreign only by passing down the `me3_mod_protocol::Game` enum. It still needs more work because the ER/AC6 fix does not work, but the infinite loop is still there.

Closes #98