### PR TITLE
Require Steam to be running before launching the game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix mod host crash handler being uninstalled as soon as it was created by @Dasaav-dsv in <https://github.com/garyttierney/me3/pull/91>
 - Address some file overrides not being loaded in Nightreign by @Dasaav-dsv in <https://github.com/garyttierney/me3/pull/111>
 - Fix Wwise soundbank and loose wem overrides in ER/AC6/NR by @Dasaav-dsv in <https://github.com/garyttierney/me3/pull/128>
+- Convey that Steam is required and fix launcher panic when Steam isn't open by @Dasaav-dsv
 
 ## [v0.4.0] - 2025-06-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,6 +1769,7 @@ dependencies = [
  "sentry",
  "toml",
  "tracing",
+ "windows 0.61.1",
 ]
 
 [[package]]

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -15,6 +15,9 @@ crash-context.workspace = true
 eyre = { version = "0.6", default-features = false, features = [
     "track-caller",
 ] }
+windows = { version = "0.61", features = [
+    "Win32_System_LibraryLoader",
+] }
 dll-syringe.workspace = true
 ipc-channel.workspace = true
 me3-launcher-attach-protocol.workspace = true

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -22,9 +22,10 @@ use me3_telemetry::TelemetryConfig;
 use minidump_writer::minidump_writer::MinidumpWriter;
 use tracing::{error, info};
 
-use crate::game::Game;
+use crate::{game::Game, steam::require_steam};
 
 mod game;
+mod steam;
 
 pub type LauncherResult<T> = eyre::Result<T>;
 
@@ -48,6 +49,8 @@ fn run() -> LauncherResult<()> {
         "Starting game at {:?} with DLL {:?}",
         args.exe, args.host_dll
     );
+
+    require_steam(&args.exe)?;
 
     let monitor_shutdown_requested = Arc::new(AtomicBool::new(false));
 

--- a/crates/launcher/src/steam.rs
+++ b/crates/launcher/src/steam.rs
@@ -1,0 +1,35 @@
+use std::{mem, path::Path};
+
+use eyre::OptionExt;
+use tracing::instrument;
+use windows::{
+    core::{s, HSTRING},
+    Win32::{
+        Foundation::FreeLibrary,
+        System::LibraryLoader::{GetProcAddress, LoadLibraryW},
+    },
+};
+
+use crate::LauncherResult;
+
+#[instrument(skip_all, err)]
+pub fn require_steam<P: AsRef<Path>>(game_binary: P) -> LauncherResult<()> {
+    let steam_dll = game_binary.as_ref().with_file_name("steam_api64.dll");
+
+    let handle = unsafe { LoadLibraryW(&HSTRING::from(&*steam_dll))? };
+
+    let steam_api_init = unsafe {
+        mem::transmute::<_, extern "system" fn() -> bool>(
+            GetProcAddress(handle, s!("SteamAPI_Init"))
+                .ok_or_eyre("SteamAPI_Init export not found")?,
+        )
+    };
+
+    let result = steam_api_init()
+        .then_some(())
+        .ok_or_eyre("Steam is required to run this game");
+
+    unsafe { FreeLibrary(handle)? };
+
+    result
+}


### PR DESCRIPTION
Add `require_steam` fn to the launcher which loads `steam_api64.dll` from the game folder and calls `SteamAPI_Init` to determine if Steam is running and the Steam account has a valid game license.