### PR TITLE
fix(overrides): UXM disk overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "cxx-stl",
  "from-singleton",
  "me3-mod-protocol",
+ "normpath",
  "pelite",
  "regex",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ me3-launcher-attach-protocol = { path = "crates/launcher-attach-protocol" }
 me3-mod-host = { path = "crates/mod-host" }
 me3-mod-protocol = { path = "crates/mod-protocol" }
 me3-mod-host-assets = { path = "crates/mod-host-assets" }
+normpath = "1.3.0"
 schemars = "0.9"
 serde = "1"
 serde_derive = "1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,12 +29,12 @@ me3-env = { version = "0.5.0", path = "../env" }
 me3-launcher-attach-protocol.workspace = true
 me3-mod-protocol.workspace = true
 me3_telemetry = { path = "../telemetry" }
-normpath = "1.3.0"
 open = { version = "5.3.2" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 steamlocate = "2.0.1"
 tempfile = "3.20.0"
+normpath.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-error.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -13,6 +13,7 @@ from-singleton = { version = "2", features = ["regex-unicode"] }
 undname = "2.1"
 pelite = "0.10"
 regex = "1"
+normpath = "1.3.0"
 thiserror.workspace = true
 me3-mod-protocol.workspace = true
 tracing.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -13,7 +13,7 @@ from-singleton = { version = "2", features = ["regex-unicode"] }
 undname = "2.1"
 pelite = "0.10"
 regex = "1"
-normpath = "1.3.0"
+normpath.workspace = true
 thiserror.workspace = true
 me3-mod-protocol.workspace = true
 tracing.workspace = true

--- a/crates/mod-host-assets/src/dl_device.rs
+++ b/crates/mod-host-assets/src/dl_device.rs
@@ -286,7 +286,7 @@ impl DlDeviceManagerGuard {
         }
     }
 
-    pub fn expand_path<'a>(&self, path: &'a [u16]) -> Option<Cow<'a, [u16]>> {
+    pub fn expand_path<'a>(&self, path: &'a [u16]) -> Cow<'a, [u16]> {
         let device_manager = unsafe { self.inner.as_ref() };
 
         let mut expanded = Cow::Borrowed(path);
@@ -312,7 +312,7 @@ impl DlDeviceManagerGuard {
             }
         }
 
-        Some(expanded)
+        expanded
     }
 
     pub fn open_disk_file_fn(&self) -> DlDeviceOpen {

--- a/crates/mod-host-assets/src/mapping.rs
+++ b/crates/mod-host-assets/src/mapping.rs
@@ -61,7 +61,13 @@ impl ArchiveOverrideMapping {
         &mut self,
         base_directory: P,
     ) -> Result<(), ArchiveOverrideMappingError> {
-        let base_directory = base_directory.as_ref().to_path_buf();
+        let base_directory = base_directory
+            .as_ref()
+            .to_path_buf()
+            .normalize()
+            .map_err(ArchiveOverrideMappingError::ReadDir)?
+            .into_path_buf();
+
         if !base_directory.is_dir() {
             return Err(ArchiveOverrideMappingError::InvalidDirectory(
                 base_directory.to_path_buf(),

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -126,12 +126,11 @@ fn hook_ebl_utility(
             let path_cstr = PCWSTR::from_raw(path);
             let expanded = unsafe { device_manager.expand_path(path_cstr.as_wide()) };
 
-            if let Some(expanded) = expanded.map(|ex| OsString::from_wide(&ex)) {
-                let expanded = expanded.to_string_lossy();
-
-                if mapping.get_override(&expanded).is_some() {
-                    return None;
-                }
+            if mapping
+                .get_override(OsString::from_wide(&expanded))
+                .is_some()
+            {
+                return None;
             }
 
             let _guard = device_manager.push_vfs(&VFS.lock().unwrap());
@@ -170,7 +169,7 @@ fn hook_ebl_utility(
         })
         .install()?;
 
-    info!("type" = "ebl", "applied asset override hook");
+    info!("applied asset override hook");
 
     Ok(())
 }
@@ -197,12 +196,9 @@ fn hook_device_manager(
 
             let expanded = DlDeviceManager::lock(device_manager).expand_path(path.as_bytes());
 
-            let expanded = expanded
-                .map(|ex| OsString::from_wide(&ex))?
-                .to_string_lossy()
-                .to_string();
+            let (mapped_path, mapped_override) =
+                mapping.get_override(OsString::from_wide(&expanded))?;
 
-            let (mapped_path, mapped_override) = mapping.get_override(&expanded)?;
             info!("override" = mapped_path);
 
             let mut path = path.clone();
@@ -246,7 +242,7 @@ fn hook_device_manager(
         })
         .install()?;
 
-    info!("type" = "file", "applied asset override hook");
+    info!("applied asset override hook");
 
     Ok(())
 }
@@ -265,12 +261,7 @@ fn hook_set_path(
 
         let expanded = DlDeviceManager::lock(device_manager).expand_path(path.as_bytes());
 
-        let expanded = expanded
-            .map(|ex| OsString::from_wide(&ex))?
-            .to_string_lossy()
-            .to_string();
-
-        let (_, mapped_override) = mapping.get_override(&expanded)?;
+        let (_, mapped_override) = mapping.get_override(OsString::from_wide(&expanded))?;
 
         let mut path = path.clone();
         path.replace(mapped_override);
@@ -333,7 +324,7 @@ fn try_hook_wwise(
         })
         .install()?;
 
-    info!("type" = "wwise", "applied asset override hook");
+    info!("applied asset override hook");
 
     Ok(())
 }


### PR DESCRIPTION
Normalize all paths with `normpath` and better handle OS-encoded strings.

This addresses an issue where me3 could not provide overrides for a game patched with UXM, where a relative path like `".//////sound/soundbanksinfo.mobnkinfo"` would not be overidden.

Tested on ERR and UXM-patched NR.