### PR TITLE
feat: capture windows exceptions during native mod loads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,6 +1798,7 @@ dependencies = [
  "me3-mod-host-assets",
  "me3-mod-protocol",
  "me3_telemetry",
+ "microseh",
  "retour",
  "seq-macro",
  "serde_json",
@@ -1884,6 +1885,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "microseh"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434c4ca971bcd27ed5c8bf9a2e24aa9fcb9affc2e67696b44a80b98f3b46a015"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,10 +25,10 @@ config = "0.15.11"
 ctrlc = "3.4.7"
 directories = "6.0.0"
 is-terminal = "0.4.16"
-me3-env = { path = "../env" , version = "0.6.0-prerelease" }
+me3-env = { path = "../env", version = "0.6.0-prerelease" }
 me3-launcher-attach-protocol.workspace = true
 me3-mod-protocol.workspace = true
-me3_telemetry = { path = "../telemetry" , version = "0.6.0-prerelease" }
+me3_telemetry = { path = "../telemetry", version = "0.6.0-prerelease" }
 open = { version = "5.3.2" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -45,6 +45,7 @@ me3_telemetry = { path = "../telemetry" , version = "0.6.0-prerelease" }
 libloading = "0.8.8"
 me3-env = { path = "../env" , version = "0.6.0-prerelease" }
 color-eyre = "0.6.5"
+microseh = "1.1.2"
 
 [lints]
 workspace = true

--- a/typos.toml
+++ b/typos.toml
@@ -1,4 +1,8 @@
 [files]
 extend-exclude = ["CHANGELOG.md"]
+
 [default]
+extend-ignore-words-re = [
+    "seh", # structured exception handling
+]
 extend-ignore-re = ["(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"]


### PR DESCRIPTION
When we load a native mod there's potential for it to raise a Windows exception and crash the mod host. Now we catch that exception and display a warning to the user that the mod may not be working as expected.