### PR TITLE
feat(sekiro): support Sekiro

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -43,6 +43,7 @@ impl ValueEnum for Game {
     fn value_variants<'a>() -> &'a [Self] {
         use me3_mod_protocol::Game as G;
         &[
+            Game(G::Sekiro),
             Game(G::EldenRing),
             Game(G::Nightreign),
             Game(G::ArmoredCore6),
@@ -52,6 +53,7 @@ impl ValueEnum for Game {
     fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
         use me3_mod_protocol::Game as G;
         Some(match self.0 {
+            G::Sekiro => PossibleValue::new("sekiro").alias("sdt"),
             G::EldenRing => PossibleValue::new("eldenring").aliases(["er", "elden-ring"]),
             G::Nightreign => PossibleValue::new("nightreign").aliases(["nr", "nightrein"]),
             G::ArmoredCore6 => PossibleValue::new("armoredcore6").alias("ac6"),
@@ -64,6 +66,7 @@ impl Game {
         use me3_mod_protocol::Game as G;
 
         match self.0 {
+            G::Sekiro => 814380,
             G::EldenRing => 1245620,
             G::Nightreign => 2622380,
             G::ArmoredCore6 => 1888160,
@@ -74,6 +77,7 @@ impl Game {
         use me3_mod_protocol::Game as G;
 
         PathBuf::from(match self.0 {
+            G::Sekiro => "sekiro.exe",
             G::EldenRing => "Game/eldenring.exe",
             G::Nightreign => "Game/nightreign.exe",
             G::ArmoredCore6 => "Game/armoredcore6.exe",
@@ -84,6 +88,7 @@ impl Game {
         use me3_mod_protocol::Game as G;
 
         let game = match id {
+            814380 => G::Sekiro,
             1245620 => G::EldenRing,
             2622380 => G::Nightreign,
             1888160 => G::ArmoredCore6,

--- a/crates/mod-host-assets/src/ebl.rs
+++ b/crates/mod-host-assets/src/ebl.rs
@@ -14,65 +14,44 @@ pub struct EblFileManager;
 #[derive(Debug)]
 pub struct EblUtilityVtable {
     pub make_ebl_object: MakeEblObject,
-    pub mount_ebl: MountEbl,
 }
 
 #[repr(C)]
 struct EblUtilityVtableER {
     _dtor: usize,
     make_ebl_object: MakeEblObject,
-    _delete_ebl_object: usize,
-    mount_ebl: MountEbl,
 }
 
 #[repr(C)]
 struct EblUtilityVtableNR {
     _dtor: usize,
     make_ebl_object: MakeEblObject,
-    _make_ebl_object_unk_str: usize,
-    _delete_ebl_object: usize,
-    mount_ebl: MountEbl,
 }
 
 type MakeEblObject =
     extern "C" fn(this: usize, path: *const u16, allocator: DlStdAllocator) -> Option<NonNull<u8>>;
 
-type MountEbl = extern "C" fn(
-    this: usize,
-    mount_name: *const u16,
-    header_path: *const u16,
-    data_path: *const u16,
-    allocator: DlStdAllocator,
-    rsa_key: *const u8,
-    key_len: usize,
-) -> bool;
-
 impl EblFileManager {
     /// # Safety
     /// Same as [`find_vmt`].
-    pub unsafe fn ebl_utility_vtable(image_base: *const u8) -> Result<EblUtilityVtable, FindError> {
+    pub unsafe fn make_ebl_object(image_base: *const u8) -> Result<MakeEblObject, FindError> {
         // SAFETY: Upheld by caller.
         unsafe {
-            if let Some(vtable) = Self::ebl_utility_vtable_from_singleton(image_base) {
-                return Ok(vtable);
+            if let Some(make_ebl_object) = Self::make_ebl_object_from_singleton(image_base) {
+                return Ok(make_ebl_object);
             }
 
             find_vmt(image_base, "DLEncryptedBinderLightUtility").map(|ptr| {
                 let &EblUtilityVtableER {
-                    make_ebl_object,
-                    mount_ebl,
-                    ..
+                    make_ebl_object, ..
                 } = ptr.as_ref();
 
-                EblUtilityVtable {
-                    make_ebl_object,
-                    mount_ebl,
-                }
+                make_ebl_object
             })
         }
     }
 
-    unsafe fn ebl_utility_vtable_from_singleton(image_base: *const u8) -> Option<EblUtilityVtable> {
+    unsafe fn make_ebl_object_from_singleton(image_base: *const u8) -> Option<MakeEblObject> {
         unsafe {
             let ptr = from_singleton::address_of::<Self>()?.cast::<*const u8>();
 
@@ -80,11 +59,9 @@ impl EblFileManager {
 
             // Depending on Dantelion2 version, there may be a vtable for the CSEblFileManager
             // instance before the EblUtilityVtable pointer.
-            let (make_ebl_object, mount_ebl) = if rdata.as_ptr_range().contains(ptr.as_ref()) {
+            if rdata.as_ptr_range().contains(ptr.as_ref()) {
                 let &EblUtilityVtableER {
-                    make_ebl_object,
-                    mount_ebl,
-                    ..
+                    make_ebl_object, ..
                 } = ptr
                     .add(1)
                     .read()
@@ -92,25 +69,18 @@ impl EblFileManager {
                     .as_ref()?
                     .as_ref()?;
 
-                (make_ebl_object, mount_ebl)
+                Some(make_ebl_object)
             } else {
                 let &EblUtilityVtableNR {
-                    make_ebl_object,
-                    mount_ebl,
-                    ..
+                    make_ebl_object, ..
                 } = ptr
                     .read()
                     .cast::<*const EblUtilityVtableNR>()
                     .as_ref()?
                     .as_ref()?;
 
-                (make_ebl_object, mount_ebl)
-            };
-
-            Some(EblUtilityVtable {
-                make_ebl_object,
-                mount_ebl,
-            })
+                Some(make_ebl_object)
+            }
         }
     }
 }

--- a/crates/mod-protocol/src/lib.rs
+++ b/crates/mod-protocol/src/lib.rs
@@ -23,16 +23,19 @@ pub enum ModProfile {
     Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
 )]
 pub enum Game {
-    #[serde(alias = "eldenring")]
+    #[serde(rename = "sekiro")]
+    Sekiro,
+
     #[serde(rename = "elden-ring")]
+    #[serde(alias = "eldenring")]
     EldenRing,
 
     #[serde(rename = "armoredcore6")]
     #[serde(alias = "ac6")]
     ArmoredCore6,
 
-    #[serde(alias = "nightrein")]
     #[serde(rename = "nightreign")]
+    #[serde(alias = "nightrein")]
     Nightreign,
 }
 

--- a/crates/mod-protocol/src/lib.rs
+++ b/crates/mod-protocol/src/lib.rs
@@ -24,6 +24,7 @@ pub enum ModProfile {
 )]
 pub enum Game {
     #[serde(rename = "sekiro")]
+    #[serde(alias = "sdt")]
     Sekiro,
 
     #[serde(rename = "elden-ring")]

--- a/schemas/mod-profile.json
+++ b/schemas/mod-profile.json
@@ -36,6 +36,7 @@
       "description": "Chronologically sorted list of games supported by me3.\n\n Feature gates can use [`Ord`] comparisons between game type constants.",
       "type": "string",
       "enum": [
+        "sekiro",
         "elden-ring",
         "armoredcore6",
         "nightreign"


### PR DESCRIPTION
Add first-class support for Sekiro mods, and `sekiro` (alias `sdt`) as a CLI flag.

Remove unnecessary asset override hook (that did not work in Sekiro and did nothing in other games).