### PR TITLE
chore: Release v0.6.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,7 +22,8 @@ body:
       description: What version of our software are you running?
       options:
         - prerelease
-            - v0.6.0 (Latest)
+        - v0.6.1 (Latest)
+            - v0.6.0
             - v0.6.0
             - v0.6.0
             - v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 <!-- markdown-link-check-disable -->
 <!-- ignore lint rules that are often triggered by content generated from commits / git-cliff -->
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
+## me3 - [v0.6.1](https://github.com/garyttierney/me3/releases/v0.6.1) - 2025-06-30
+
+### 🐛 Bug Fixes
+
+- [9c99ad9](https://github.com/garyttierney/me3/commit/9c99ad95a1191c4dd31876afcd7cd5343388a66b) Don't overwrite profiles unless requested in [#264](https://github.com/garyttierney/me3/pull/264)
+
+
 ## me3 - [v0.6.0](https://github.com/garyttierney/me3/releases/v0.6.0) - 2025-06-29
 
 ### 🚀 Features
@@ -1997,6 +2004,7 @@ All notable changes to this project will be documented in this file.
 - [c4e6ef5](https://github.com/garyttierney/me3/commit/c4e6ef502776db75d89dbfef6c585b658a28caf4) Initial commit
 
 
+[0.6.1]: https://github.com/garyttierney/me3/compare/v0.6.0..v0.6.1
 [0.6.0]: https://github.com/garyttierney/me3/compare/v0.5.0..v0.6.0
 [0.5.0]: https://github.com/garyttierney/me3/compare/v0.4.0..v0.5.0
 [0.4.0]: https://github.com/garyttierney/me3/compare/v0.3.0..v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "clap",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "me3-env"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crash-context",
  "dll-syringe",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bincode",
  "eyre",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "closure-ffi",
  "color-eyre",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cxx-stl",
  "from-singleton",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "expect-test",
  "schemars",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "color-eyre",
  "eyre",
@@ -3694,7 +3694,7 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xtask"
-version = "0.6.0"
+version = "0.6.1"
 
 [[package]]
 name = "yoke"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-env"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/launcher-attach-protocol/Cargo.toml
+++ b/crates/launcher-attach-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "me3-launcher-attach-protocol"
 edition = "2021"
-version = "0.6.0"
+version = "0.6.1"
 repository.workspace = true
 license.workspace = true
 description = "Wire protocol for me3 launcher<->host traffic"

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher"
-version = "0.6.0"
+version = "0.6.1"
 repository.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-assets"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "me3-mod-protocol"
 edition = "2021"
-version = "0.6.0"
+version = "0.6.1"
 repository.workspace = true
 license.workspace = true
 description = "Schema definition for me3 mod profiles"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3_telemetry"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039  # local is non-POSIX
 set -u
 
-INSTALLER_VERSION=v0.6.0
+INSTALLER_VERSION=v0.6.1
 
 need_cmd() {
     if ! check_cmd "$1"; then


### PR DESCRIPTION
## me3 - [v0.6.1](https://github.com/garyttierney/me3/releases/v0.6.1) - 2025-06-30

### 🐛 Bug Fixes

- [9c99ad9](https://github.com/garyttierney/me3/commit/9c99ad95a1191c4dd31876afcd7cd5343388a66b) Don't overwrite profiles unless requested in [#264](https://github.com/garyttierney/me3/pull/264)