### PR TITLE
chore: Release v0.6.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,7 +22,8 @@ body:
       description: What version of our software are you running?
       options:
         - prerelease
-        - v0.6.1 (Latest)
+        - v0.6.2 (Latest)
+        - v0.6.1
         - v0.6.0
         - v0.5.0
         - v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to this project will be documented in this file.
 <!-- markdown-link-check-disable -->
 <!-- ignore lint rules that are often triggered by content generated from commits / git-cliff -->
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
+## me3 - [v0.6.2](https://github.com/garyttierney/me3/releases/v0.6.2) - 2025-07-04
+
+### 🐛 Bug Fixes
+
+- [5896daf](https://github.com/garyttierney/me3/commit/5896dafded3d3b88364a4bfadce24aca204bbf67) Validate mod profile filepaths in [#287](https://github.com/garyttierney/me3/pull/287)
+
+
+  > Skip invalid and nonexistent paths in mod profiles before passing them
+  > to the mod host, preventing hard errors.
+
+  > Closes #240
+
+- [a5e3db4](https://github.com/garyttierney/me3/commit/a5e3db4db6cbcc0b19d8da161450e605aa8a8325) Don't stop path discovery on every filesystem error
+
+
+
+- [c5fb8cc](https://github.com/garyttierney/me3/commit/c5fb8cc8a64d6178bb9eb0bd78436af310963890) Exclude nonexistent paths and warn the user
+
+
+
+- [c12976d](https://github.com/garyttierney/me3/commit/c12976dcc7a0695adefc7f4b52cbc12d7fd479be) Don't block shutdown with monitor thread in [#285](https://github.com/garyttierney/me3/pull/285)
+
+
+  > This exists purely to signal minidump crash events, which are currently
+  > not enabled in the latest release. Get rid of the infrastructure for
+  > handling it via pipes, and we'll use `WaitForMultipleObjects` on the
+  > process/crash event.
+
+  > Additionally switch the mod host to logging to `stdout`, so we capture
+  > logs from any other DLL mods in use.
+
+  > Fixes #270.
+
+- [aa10096](https://github.com/garyttierney/me3/commit/aa10096e16f715871ba9c4db50f9608c8ff27f22) Add singular profile aliases for packages/natives in [#283](https://github.com/garyttierney/me3/pull/283)
+
+
+
+- [c38f7e6](https://github.com/garyttierney/me3/commit/c38f7e675a0e84b33037ac7a5658716e4c3019b0) Add .sh extension to example Linux scripts in [#282](https://github.com/garyttierney/me3/pull/282)
+
+
+  > Closes #280
+
+- [bed1c98](https://github.com/garyttierney/me3/commit/bed1c980da385e02c4cab436686bb73de18ceaf5) Version list in GitHub issue template in [#278](https://github.com/garyttierney/me3/pull/278)
+
+
+
+### 📚 Documentation
+
+- [b19b629](https://github.com/garyttierney/me3/commit/b19b629120dcafb5dd90129d2a9583c88a6783ec) Complete initial release documentation tasks in [#284](https://github.com/garyttierney/me3/pull/284)
+
+
 ## me3 - [v0.6.1](https://github.com/garyttierney/me3/releases/v0.6.1) - 2025-06-30
 
 ### 🐛 Bug Fixes
@@ -2004,6 +2055,7 @@ All notable changes to this project will be documented in this file.
 - [c4e6ef5](https://github.com/garyttierney/me3/commit/c4e6ef502776db75d89dbfef6c585b658a28caf4) Initial commit
 
 
+[0.6.2]: https://github.com/garyttierney/me3/compare/v0.6.1..v0.6.2
 [0.6.1]: https://github.com/garyttierney/me3/compare/v0.6.0..v0.6.1
 [0.6.0]: https://github.com/garyttierney/me3/compare/v0.5.0..v0.6.0
 [0.5.0]: https://github.com/garyttierney/me3/compare/v0.4.0..v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
 dependencies = [
  "shlex",
 ]
@@ -1181,6 +1181,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "clap",
@@ -1430,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "me3-env"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1438,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "crash-context",
  "dll-syringe",
@@ -1457,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bincode",
  "eyre",
@@ -1468,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "closure-ffi",
  "color-eyre",
@@ -1493,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cxx-stl",
  "from-singleton",
@@ -1509,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "expect-test",
  "schemars",
@@ -1522,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "color-eyre",
  "eyre",
@@ -2626,6 +2637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
 name = "slice-pool2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,16 +2874,18 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "windows-sys 0.52.0",
 ]
@@ -3694,7 +3713,7 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xtask"
-version = "0.6.1"
+version = "0.6.2"
 
 [[package]]
 name = "yoke"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-cli"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-env"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/launcher-attach-protocol/Cargo.toml
+++ b/crates/launcher-attach-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "me3-launcher-attach-protocol"
 edition = "2021"
-version = "0.6.1"
+version = "0.6.2"
 repository.workspace = true
 license.workspace = true
 description = "Wire protocol for me3 launcher<->host traffic"

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher"
-version = "0.6.1"
+version = "0.6.2"
 repository.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-assets"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "me3-mod-protocol"
 edition = "2021"
-version = "0.6.1"
+version = "0.6.2"
 repository.workspace = true
 license.workspace = true
 description = "Schema definition for me3 mod profiles"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3_telemetry"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039  # local is non-POSIX
 set -u
 
-INSTALLER_VERSION=v0.6.1
+INSTALLER_VERSION=v0.6.2
 
 need_cmd() {
     if ! check_cmd "$1"; then


### PR DESCRIPTION
## me3 - [v0.6.2](https://github.com/garyttierney/me3/releases/v0.6.2) - 2025-07-04

### 🐛 Bug Fixes

- [5896daf](https://github.com/garyttierney/me3/commit/5896dafded3d3b88364a4bfadce24aca204bbf67) Validate mod profile filepaths in [#287](https://github.com/garyttierney/me3/pull/287)


  > Skip invalid and nonexistent paths in mod profiles before passing them
  > to the mod host, preventing hard errors.

  > Closes #240

- [a5e3db4](https://github.com/garyttierney/me3/commit/a5e3db4db6cbcc0b19d8da161450e605aa8a8325) Don't stop path discovery on every filesystem error



- [c5fb8cc](https://github.com/garyttierney/me3/commit/c5fb8cc8a64d6178bb9eb0bd78436af310963890) Exclude nonexistent paths and warn the user



- [c12976d](https://github.com/garyttierney/me3/commit/c12976dcc7a0695adefc7f4b52cbc12d7fd479be) Don't block shutdown with monitor thread in [#285](https://github.com/garyttierney/me3/pull/285)


  > This exists purely to signal minidump crash events, which are currently
  > not enabled in the latest release. Get rid of the infrastructure for
  > handling it via pipes, and we'll use `WaitForMultipleObjects` on the
  > process/crash event.

  > Additionally switch the mod host to logging to `stdout`, so we capture
  > logs from any other DLL mods in use.

  > Fixes #270.

- [aa10096](https://github.com/garyttierney/me3/commit/aa10096e16f715871ba9c4db50f9608c8ff27f22) Add singular profile aliases for packages/natives in [#283](https://github.com/garyttierney/me3/pull/283)



- [c38f7e6](https://github.com/garyttierney/me3/commit/c38f7e675a0e84b33037ac7a5658716e4c3019b0) Add .sh extension to example Linux scripts in [#282](https://github.com/garyttierney/me3/pull/282)


  > Closes #280

- [bed1c98](https://github.com/garyttierney/me3/commit/bed1c980da385e02c4cab436686bb73de18ceaf5) Version list in GitHub issue template in [#278](https://github.com/garyttierney/me3/pull/278)



### 📚 Documentation

- [b19b629](https://github.com/garyttierney/me3/commit/b19b629120dcafb5dd90129d2a9583c88a6783ec) Complete initial release documentation tasks in [#284](https://github.com/garyttierney/me3/pull/284)