### PR TITLE
fix: Don't block shutdown with monitor thread

### DIFF
--- a/crates/launcher-attach-protocol/src/lib.rs
+++ b/crates/launcher-attach-protocol/src/lib.rs
@@ -9,8 +9,6 @@ use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AttachRequest {
-    pub monitor_handle: usize,
-
     pub config: AttachConfig,
 }
 
@@ -51,7 +49,6 @@ impl<E: Into<eyre::Report>> From<E> for AttachError {
 
 #[derive(Debug, Decode, Encode)]
 pub enum HostMessage {
-    Attached,
     CrashDumpRequest {
         /// The address of an `EXCEPTION_POINTERS` in the client's memory
         exception_pointers: u64,

--- a/crates/mod-host/src/detour.rs
+++ b/crates/mod-host/src/detour.rs
@@ -12,13 +12,13 @@ pub struct Detour<F: Function> {
 
 impl<F: Function> Detour<F> {
     pub unsafe fn disable(&self) -> Result<(), DetourError> {
-        self.detour.disable()?;
+        unsafe { self.detour.disable()? };
 
         Ok(())
     }
 
     pub unsafe fn enable(&self) -> Result<(), DetourError> {
-        self.detour.enable()?;
+        unsafe { self.detour.enable()? };
 
         Ok(())
     }


### PR DESCRIPTION
This exists purely to signal minidump crash events, which are currently not enabled in the latest release. Get rid of the infrastructure for handling it via pipes, and we'll use `WaitForMultipleObjects` on the process/crash event.

Additionally switch the mod host to logging to `stdout`, so we capture logs from any other DLL mods in use.

Fixes #270.