### PR TITLE
chore(dev): remove microseh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,6 @@ dependencies = [
  "me3-mod-host-assets",
  "me3-mod-protocol",
  "me3_telemetry",
- "microseh",
  "retour",
  "seq-macro",
  "serde_json",
@@ -1557,15 +1556,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "microseh"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434c4ca971bcd27ed5c8bf9a2e24aa9fcb9affc2e67696b44a80b98f3b46a015"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -26,7 +26,6 @@ me3-launcher-attach-protocol.workspace = true
 me3-mod-host-assets.workspace = true
 me3-mod-protocol.workspace = true
 me3-telemetry.workspace = true
-microseh = "1.1.2"
 retour = { git = "https://github.com/Hpmason/retour-rs" }
 seq-macro = "0.3.6"
 serde_json.workspace = true


### PR DESCRIPTION
Fixes builds targeting `x86_64-pc-windows-gnu` and `x86_64-pc-windows-gnullvm`, which could not compile due to the `microseh` crate.