### PR TITLE
chore(docs): Reference Mod Engine2 in docs for Google SEO

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ hide:
 
 # Welcome to me3
 
-**me<sup>3</sup>** is a framework designed for runtime modification of games, with a focus on ELDEN RING and other titles from FROMSOFTWARE.
+**me<sup>3</sup>** is a framework designed for runtime modification of games, with a focus on ELDEN RING and other titles from FROMSOFTWARE. It is the successor to [Mod Engine 2](https://github.com/garyttierney/me3).
 
 [Download :fontawesome-solid-download:](https://github.com/garyttierney/me3/releases/latest){ .md-button .md-button--primary }
 

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -6,3 +6,4 @@ mkdocs-material @ git+https://${GITHUB_MKDOCS_INSIDERS_TOKEN}@github.com/garytti
 mkdocs-material-extensions==1.3.1
 mkdocs-static-i18n==1.3.0
 mkdocs-git-committers-plugin-2==2.5.0
+mkdocs-meta-descriptions-plugin==4.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,6 +10,8 @@ babel==2.17.0
     #   mkdocs-material
 backrefs==5.9
     # via mkdocs-material
+beautifulsoup4==4.13.4
+    # via mkdocs-meta-descriptions-plugin
 certifi==2025.6.15
     # via requests
 charset-normalizer==3.4.2
@@ -53,6 +55,7 @@ mkdocs==1.6.1
     #   mkdocs-git-committers-plugin-2
     #   mkdocs-git-revision-date-localized-plugin
     #   mkdocs-material
+    #   mkdocs-meta-descriptions-plugin
     #   mkdocs-static-i18n
 mkdocs-get-deps==0.2.0
     # via
@@ -70,10 +73,14 @@ mkdocs-material-extensions==1.3.1
     # via
     #   -r docs/requirements.in
     #   mkdocs-material
+mkdocs-meta-descriptions-plugin==4.1.0
+    # via -r docs/requirements.in
 mkdocs-static-i18n==1.3.0
     # via -r docs/requirements.in
 packaging==25.0
-    # via mkdocs
+    # via
+    #   mkdocs
+    #   mkdocs-meta-descriptions-plugin
 paginate==0.5.7
     # via mkdocs-material
 pathspec==0.12.1
@@ -83,7 +90,9 @@ platformdirs==4.3.8
 pygments==2.19.2
     # via mkdocs-material
 pymdown-extensions==10.16
-    # via mkdocs-material
+    # via
+    #   mkdocs-material
+    #   mkdocs-meta-descriptions-plugin
 python-dateutil==2.9.0.post0
     # via ghp-import
 pytz==2025.2
@@ -104,6 +113,10 @@ six==1.17.0
     # via python-dateutil
 smmap==5.0.2
     # via gitdb
+soupsieve==2.7
+    # via beautifulsoup4
+typing-extensions==4.14.1
+    # via beautifulsoup4
 urllib3==2.5.0
     # via requests
 watchdog==6.0.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ plugins:
   - meta
   - search
   - optimize
+  - meta-descriptions
   - git-committers:
       repository: garyttierney/me3
       branch: main


### PR DESCRIPTION
A lot of search queries for me3 are written as "mod engine 3", so reference Mod Engine 2 to promote results for users looking for a newer version of ModEngine.