### PR TITLE
Chinese (language) not Chinese (nationality)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,7 @@ extra:
     - name: English
       link: /en/
       lang: en
-    - name: 中国人
+    - name: 中文
       link: /zh/
       lang: zh
     - name: Polski
@@ -126,7 +126,7 @@ plugins:
           name: English
           build: true
         - locale: zh
-          name: 中国人
+          name: 中文
           build: false
         - locale: pl
           name: Polski


### PR DESCRIPTION
中国人 = Chinese (nationality)
中文 = Chinese (language)

Good reference for localised language names is [List of Wikipedias](https://meta.wikimedia.org/wiki/Special:MyLanguage/List_of_Wikipedias)