### PR TITLE
fix(host): Use filesystem hooks

### DIFF
--- a/crates/mod-host-assets/src/wwise.rs
+++ b/crates/mod-host-assets/src/wwise.rs
@@ -79,7 +79,7 @@ fn get_override<'a>(
 ) -> Option<(&'a str, &'a [u16])> {
     for prefix in PREFIXES {
         let prefixed = format!("{prefix}/{input}");
-        if let Some(replacement) = mapping.get_override(&prefixed) {
+        if let Some(replacement) = mapping.vfs_override(&prefixed) {
             return Some(replacement);
         }
     }

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -32,12 +32,13 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 windows = { workspace = true, features = [
-    "Wdk_System_Threading",
-    "Win32_System_Memory",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Diagnostics_Debug",
-    "Win32_System_Threading",
-    "Win32_System_SystemInformation",
     "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
+    "Win32_System_SystemInformation",
+    "Win32_System_Threading",
 ] }
 
 [build-dependencies]

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -139,7 +139,7 @@ fn hook_ebl_utility(
             let expanded = unsafe { device_manager.expand_path(path_cstr.as_wide()) };
 
             if mapping
-                .get_override(OsString::from_wide(&expanded))
+                .vfs_override(OsString::from_wide(&expanded))
                 .is_some()
             {
                 return None;
@@ -175,7 +175,7 @@ fn hook_device_manager(
             let expanded = DlDeviceManager::lock(device_manager).expand_path(path.as_bytes());
 
             let (mapped_path, mapped_override) =
-                mapping.get_override(OsString::from_wide(&expanded))?;
+                mapping.vfs_override(OsString::from_wide(&expanded))?;
 
             info!("override" = mapped_path);
 
@@ -241,7 +241,7 @@ fn hook_set_path(
 
         let expanded = DlDeviceManager::lock(device_manager).expand_path(path.as_bytes());
 
-        let (_, mapped_override) = mapping.get_override(OsString::from_wide(&expanded))?;
+        let (_, mapped_override) = mapping.vfs_override(OsString::from_wide(&expanded))?;
 
         let mut path = path.clone();
         path.replace(mapped_override);

--- a/crates/mod-host/src/filesystem.rs
+++ b/crates/mod-host/src/filesystem.rs
@@ -1,0 +1,234 @@
+use std::{
+    ffi::OsString,
+    mem,
+    os::windows::{ffi::OsStringExt, raw::HANDLE},
+    sync::Arc,
+};
+
+use eyre::OptionExt;
+use me3_mod_host_assets::mapping::ArchiveOverrideMapping;
+use tracing::{info, info_span, instrument};
+use windows::{
+    core::{s, w, BOOL, PCWSTR},
+    Win32::{
+        Foundation::HMODULE,
+        Security::SECURITY_ATTRIBUTES,
+        Storage::FileSystem::{
+            CREATEFILE2_EXTENDED_PARAMETERS, FILE_CREATION_DISPOSITION, FILE_FLAGS_AND_ATTRIBUTES,
+            FILE_SHARE_MODE,
+        },
+        System::LibraryLoader::{GetModuleHandleW, GetProcAddress},
+    },
+};
+
+use crate::host::ModHost;
+
+#[instrument(name = "filesystem", skip_all)]
+pub fn attach_override(mapping: Arc<ArchiveOverrideMapping>) -> Result<(), eyre::Error> {
+    let kernelbase = unsafe { GetModuleHandleW(w!("kernelbase.dll"))? };
+
+    hook_create_file(kernelbase, mapping.clone())?;
+
+    hook_create_directory(kernelbase, mapping.clone())?;
+
+    hook_delete_file(kernelbase, mapping.clone())?;
+
+    Ok(())
+}
+
+#[instrument(name = "create_file", skip_all)]
+fn hook_create_file(kb: HMODULE, mapping: Arc<ArchiveOverrideMapping>) -> Result<(), eyre::Error> {
+    type CreateFileW = unsafe extern "C" fn(
+        lpfilename: PCWSTR,
+        dwdesiredaccess: u32,
+        dwsharemode: FILE_SHARE_MODE,
+        lpsecurityattributes: *const SECURITY_ATTRIBUTES,
+        dwcreationdisposition: FILE_CREATION_DISPOSITION,
+        dwflagsandattributes: FILE_FLAGS_AND_ATTRIBUTES,
+        htemplatefile: HANDLE,
+    ) -> HANDLE;
+
+    type CreateFile2 = unsafe extern "C" fn(
+        lpfilename: PCWSTR,
+        dwdesiredaccess: u32,
+        dwsharemode: FILE_SHARE_MODE,
+        dwcreationdisposition: FILE_CREATION_DISPOSITION,
+        pcreateexparams: *const CREATEFILE2_EXTENDED_PARAMETERS,
+    ) -> HANDLE;
+
+    let (create_file_w, create_file_2) = unsafe {
+        let create_file_w =
+            GetProcAddress(kb, s!("CreateFileW")).ok_or_eyre("CreateFileW not found")?;
+        let create_file_2 =
+            GetProcAddress(kb, s!("CreateFile2")).ok_or_eyre("CreateFile2 not found")?;
+
+        (
+            mem::transmute::<_, CreateFileW>(create_file_w),
+            mem::transmute::<_, CreateFile2>(create_file_2),
+        )
+    };
+
+    let hook_span = info_span!("hook");
+
+    ModHost::get_attached_mut()
+        .hook(create_file_w)
+        .with_closure({
+            let mapping = mapping.clone();
+            let hook_span = hook_span.clone();
+
+            move |p1, p2, p3, p4, p5, p6, p7, trampoline| unsafe {
+                let _span_guard = hook_span.enter();
+
+                if p1.is_null() {
+                    return trampoline(p1, p2, p3, p4, p5, p6, p7);
+                }
+
+                let path = OsString::from_wide(p1.as_wide());
+
+                if let Some((mapped_path, mapped_override)) = mapping.disk_override(path) {
+                    info!("override" = mapped_path);
+
+                    let p1 = PCWSTR::from_raw(mapped_override.as_ptr() as _);
+                    return trampoline(p1, p2, p3, p4, p5, p6, p7);
+                }
+
+                trampoline(p1, p2, p3, p4, p5, p6, p7)
+            }
+        })
+        .install()?;
+
+    ModHost::get_attached_mut()
+        .hook(create_file_2)
+        .with_closure({
+            let mapping = mapping.clone();
+
+            move |p1, p2, p3, p4, p5, trampoline| unsafe {
+                let _span_guard = hook_span.enter();
+
+                if p1.is_null() {
+                    return trampoline(p1, p2, p3, p4, p5);
+                }
+
+                let path = OsString::from_wide(p1.as_wide());
+
+                if let Some((mapped_path, mapped_override)) = mapping.disk_override(path) {
+                    info!("override" = mapped_path);
+
+                    let p1 = PCWSTR::from_raw(mapped_override.as_ptr() as _);
+                    return trampoline(p1, p2, p3, p4, p5);
+                }
+
+                trampoline(p1, p2, p3, p4, p5)
+            }
+        })
+        .install()?;
+
+    info!("applied filesystem hook");
+
+    Ok(())
+}
+
+#[instrument(name = "create_directory", skip_all)]
+fn hook_create_directory(
+    kb: HMODULE,
+    mapping: Arc<ArchiveOverrideMapping>,
+) -> Result<(), eyre::Error> {
+    type CreateDirectoryW = unsafe extern "C" fn(
+        lppathname: PCWSTR,
+        lpsecurityattributes: *const SECURITY_ATTRIBUTES,
+    ) -> HANDLE;
+
+    type CreateDirectoryExW = unsafe extern "C" fn(
+        lptemplatedirectory: PCWSTR,
+        lpnewdirectory: PCWSTR,
+        lpsecurityattributes: *const SECURITY_ATTRIBUTES,
+    ) -> HANDLE;
+
+    let (create_dir_w, create_dir_exw) = unsafe {
+        let create_dir_w =
+            GetProcAddress(kb, s!("CreateDirectoryW")).ok_or_eyre("CreateDirectoryW not found")?;
+        let create_dir_exw = GetProcAddress(kb, s!("CreateDirectoryExW"))
+            .ok_or_eyre("CreateDirectoryExW not found")?;
+
+        (
+            mem::transmute::<_, CreateDirectoryW>(create_dir_w),
+            mem::transmute::<_, CreateDirectoryExW>(create_dir_exw),
+        )
+    };
+
+    ModHost::get_attached_mut()
+        .hook(create_dir_w)
+        .with_closure({
+            let mapping = mapping.clone();
+
+            move |p1, p2, trampoline| unsafe {
+                if p1.is_null() {
+                    trampoline(p1, p2)
+                } else if let Some((_, mapped_override)) =
+                    mapping.disk_override(OsString::from_wide(p1.as_wide()))
+                {
+                    trampoline(PCWSTR::from_raw(mapped_override.as_ptr() as _), p2)
+                } else {
+                    trampoline(p1, p2)
+                }
+            }
+        })
+        .install()?;
+
+    ModHost::get_attached_mut()
+        .hook(create_dir_exw)
+        .with_closure({
+            let mapping = mapping.clone();
+
+            move |p1, p2, p3, trampoline| unsafe {
+                if p1.is_null() {
+                    trampoline(p1, p2, p3)
+                } else if let Some((_, mapped_override)) =
+                    mapping.disk_override(OsString::from_wide(p1.as_wide()))
+                {
+                    trampoline(PCWSTR::from_raw(mapped_override.as_ptr() as _), p2, p3)
+                } else {
+                    trampoline(p1, p2, p3)
+                }
+            }
+        })
+        .install()?;
+
+    info!("applied filesystem hook");
+
+    Ok(())
+}
+
+#[instrument(name = "delete_file", skip_all)]
+fn hook_delete_file(kb: HMODULE, mapping: Arc<ArchiveOverrideMapping>) -> Result<(), eyre::Error> {
+    type DeleteFileW = unsafe extern "C" fn(lpfilename: PCWSTR) -> BOOL;
+
+    let delete_file_w = unsafe {
+        mem::transmute::<_, DeleteFileW>(
+            GetProcAddress(kb, s!("DeleteFileW")).ok_or_eyre("DeleteFileW not found")?,
+        )
+    };
+
+    ModHost::get_attached_mut()
+        .hook(delete_file_w)
+        .with_closure({
+            let mapping = mapping.clone();
+
+            move |p1, trampoline| unsafe {
+                if p1.is_null() {
+                    trampoline(p1)
+                } else if let Some((_, mapped_override)) =
+                    mapping.disk_override(OsString::from_wide(p1.as_wide()))
+                {
+                    trampoline(PCWSTR::from_raw(mapped_override.as_ptr() as _))
+                } else {
+                    trampoline(p1)
+                }
+            }
+        })
+        .install()?;
+
+    info!("applied filesystem hook");
+
+    Ok(())
+}

--- a/crates/mod-host/src/lib.rs
+++ b/crates/mod-host/src/lib.rs
@@ -23,6 +23,7 @@ mod asset_hooks;
 mod debugger;
 mod deferred;
 mod detour;
+mod filesystem;
 mod host;
 mod native;
 
@@ -93,6 +94,8 @@ fn on_attach(request: AttachRequest) -> AttachResult {
         let mut override_mapping = ArchiveOverrideMapping::new()?;
         override_mapping.scan_directories(packages.iter())?;
         let override_mapping = Arc::new(override_mapping);
+
+        filesystem::attach_override(override_mapping.clone())?;
 
         info!("Host successfully attached");
 


### PR DESCRIPTION
During the mod host initialization routine (before loading natives) hook the following functions:

>CreateFileW, CreateFile2, CreateDirectoryW, CreateDirectoryExW, DeleteFileW

This allows for files looked up inside the game directory like mod configs and other files to be loaded from the corresponding mod packages.