### PR TITLE
refactor: Suspend process instead of debugging it

### DIFF
--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -24,7 +24,6 @@ sentry = { workspace = true, optional = true }
 toml.workspace = true
 tracing.workspace = true
 windows = { workspace = true, features = [
-    "Win32_System_Diagnostics_Debug",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
 ] }

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1,4 +1,5 @@
 #![windows_subsystem = "windows"]
+#![feature(windows_process_extensions_main_thread_handle)]
 
 use eyre::Context;
 use me3_env::{LauncherVars, TelemetryVars};

--- a/crates/mod-host/src/lib.rs
+++ b/crates/mod-host/src/lib.rs
@@ -45,7 +45,7 @@ dll_syringe::payload_procedure! {
 #[cfg(coverage)]
 #[unsafe(no_mangle)]
 #[allow(non_upper_case_globals)]
-static __lvm_profile_runtime: i32 = 1;
+static __llvm_profile_runtime: i32 = 1;
 
 #[cfg(coverage)]
 unsafe extern "C" {


### PR DESCRIPTION
Use `CREATE_SUSPENDED` instead of `DEBUG_PROCESS` on process creation and initialize the suspended process by creating a stub remote thread before injecting the dll-syringe payload.