### PR TITLE
feat(host): Skip logos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-stl"
-version = "3.4.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3ba5d51c332fde0852e7ec374e51d297361cbe0e8007f075765199951c4eb9"
+checksum = "e42cf6d86f92c165eaf2d4afa54382ec9b8d1cdef39f4265bc938cd055198f83"
 dependencies = [
  "cstl-sys",
 ]
@@ -1633,8 +1633,10 @@ dependencies = [
  "closure-ffi",
  "color-eyre",
  "crash-handler",
+ "cxx-stl",
  "dll-syringe",
  "eyre",
+ "from-singleton",
  "libloading",
  "me3-binary-analysis",
  "me3-env",
@@ -1643,6 +1645,8 @@ dependencies = [
  "me3-mod-protocol",
  "me3_telemetry",
  "pelite",
+ "rayon",
+ "regex",
  "retour",
  "rsa",
  "seq-macro",
@@ -1665,6 +1669,7 @@ dependencies = [
  "me3-mod-protocol",
  "normpath",
  "pelite",
+ "rayon",
  "regex",
  "thiserror 2.0.12",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,12 @@ color-eyre = { version = "0.6", default-features = false }
 crash-context = "0.6"
 crash-handler = "0.6"
 ctrlc = "3"
+cxx-stl = { version = "4", features = ["msvc2012"] }
 directories = "6"
 dll-syringe = { version = "0.16", default-features = false, features = ["syringe", "rpc"] }
 expect-test = "1"
 eyre = { version = "0.6", default-features = false }
+from-singleton = { version = "2", features = ["regex-unicode"] }
 is-terminal = "0.4"
 me3-binary-analysis = { path = "crates/binary-analysis" }
 me3-env = { path = "crates/env" }

--- a/crates/launcher-attach-protocol/src/lib.rs
+++ b/crates/launcher-attach-protocol/src/lib.rs
@@ -33,6 +33,9 @@ pub struct AttachConfig {
     /// Cache decrypted BHD files to improve game startup speed?
     pub boot_boost: bool,
 
+    /// Skip the intro logos shown on every game launch?
+    pub skip_logos: bool,
+
     /// Should we avoid checking if Steam is running as part of pre-launch checks?
     pub skip_steam_init: bool,
 }

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -9,10 +9,11 @@ description = "Override game assets with local versions"
 publish = false
 
 [dependencies]
-cxx-stl = { version = "3", features = ["msvc2012"] }
-from-singleton = { version = "2", features = ["regex-unicode"] }
+cxx-stl.workspace = true
+from-singleton.workspace = true
 undname = "2.1"
 pelite = "0.10"
+rayon.workspace = true
 regex = "1"
 normpath.workspace = true
 thiserror.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -19,8 +19,10 @@ crate-type = ["cdylib"]
 closure-ffi = { version = "3.0", features = ["coverage", "std", "tuple_trait"] }
 color-eyre.workspace = true
 crash-handler.workspace = true
+cxx-stl.workspace = true
 dll-syringe = { workspace = true, features = ["payload-utils"] }
 eyre = { workspace = true, default-features = false, features = ["track-caller"] }
+from-singleton.workspace = true
 libloading = "0.8.8"
 me3-binary-analysis.workspace = true
 me3-env.workspace = true
@@ -29,6 +31,8 @@ me3-mod-host-assets.workspace = true
 me3-mod-protocol.workspace = true
 me3-telemetry.workspace = true
 pelite.workspace = true
+regex.workspace = true
+rayon.workspace = true
 retour = { git = "https://github.com/Hpmason/retour-rs" }
 rsa = "0.9"
 seq-macro = "0.3.6"
@@ -37,6 +41,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 windows = { workspace = true, features = [
+    "Win32_Graphics_Gdi",
     "Win32_Globalization",
     "Win32_Security",
     "Win32_Storage_FileSystem",
@@ -45,6 +50,7 @@ windows = { workspace = true, features = [
     "Win32_System_Memory",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 xxhash-rust = { version = "0.8", features = ["std", "xxh3"] }
 

--- a/crates/mod-host/src/lib.rs
+++ b/crates/mod-host/src/lib.rs
@@ -27,6 +27,7 @@ use crate::{
     debugger::suspend_for_debugger, deferred::defer_until_init, executable::Executable,
     host::ModHost,
 };
+
 mod asset_hooks;
 mod debugger;
 mod deferred;
@@ -35,6 +36,7 @@ mod executable;
 mod filesystem;
 mod host;
 mod native;
+mod skip_logos;
 
 static INSTANCE: OnceLock<usize> = OnceLock::new();
 static mut TELEMETRY_INSTANCE: OnceLock<me3_telemetry::Telemetry> = OnceLock::new();
@@ -90,6 +92,8 @@ fn on_attach(request: AttachRequest) -> AttachResult {
         let exe = unsafe { Executable::new() };
 
         ModHost::new().attach();
+
+        skip_logos::attach_override(attach_config.clone(), exe)?;
 
         let mut override_mapping = ArchiveOverrideMapping::new()?;
         override_mapping.scan_directories(attach_config.packages.iter())?;

--- a/crates/mod-host/src/skip_logos.rs
+++ b/crates/mod-host/src/skip_logos.rs
@@ -1,0 +1,171 @@
+use std::{mem, ptr, sync::Arc};
+
+use eyre::{eyre, OptionExt};
+use me3_binary_analysis::pe;
+use me3_launcher_attach_protocol::AttachConfig;
+use me3_mod_protocol::Game;
+use pelite::pe::Pe;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use regex::bytes::Regex;
+use tracing::{error, info, instrument, Span};
+use windows::{
+    core::{s, w},
+    Win32::{
+        Foundation::COLORREF,
+        Graphics::Gdi::CreateSolidBrush,
+        System::LibraryLoader::{GetModuleHandleW, GetProcAddress},
+        UI::WindowsAndMessaging::WNDCLASSEXW,
+    },
+};
+
+use crate::{deferred::defer_until_init, executable::Executable, host::ModHost};
+
+#[instrument(name = "skip_logos", skip_all)]
+pub fn attach_override(
+    attach_config: Arc<AttachConfig>,
+    exe: Executable,
+) -> Result<(), eyre::Error> {
+    fix_show_window_flash()?;
+
+    defer_until_init(Span::current(), move || {
+        if attach_config.skip_logos {
+            // Different hooks depending on engine version.
+            let result = if attach_config.game >= Game::EldenRing {
+                skip_fd4_logos(exe)
+            } else {
+                skip_sprj_logos(exe)
+            };
+
+            if let Err(e) = result {
+                error!("error" = &*e, "can't skip logos");
+            } else {
+                info!("applied hook");
+            }
+        }
+    })?;
+
+    Ok(())
+}
+
+/// Skip logos (ELDEN RING and later games).
+#[instrument(skip_all)]
+fn skip_fd4_logos(exe: Executable) -> Result<(), eyre::Error> {
+    let [data, rdata] = pe::sections(exe, [".data", ".rdata"])
+        .map_err(|e| eyre!("PE section \"{e}\" is missing"))?;
+
+    let data = exe.get_section_bytes(data)?;
+    let rdata = exe.get_section_bytes(rdata)?;
+
+    // "TitleStep::STEP_BeginLogo" as a UTF-16 string.
+    let step_name_re = Regex::new(
+        r"(?s-u)T\x00i\x00t\x00l\x00e\x00S\x00t\x00e\x00p\x00:\x00:\x00S\x00T\x00E\x00P\x00_\x00B\x00e\x00g\x00i\x00n\x00L\x00o\x00g\x00o\x00",
+    )
+    .unwrap();
+
+    // Find the string in the .rdata section.
+    let step_name_ptr = step_name_re
+        .find(rdata)
+        .map(|m| m.as_bytes().as_ptr() as usize)
+        .ok_or_eyre("pattern returned no matches")?;
+
+    let (_, data_ptrs, _) = unsafe { data.align_to::<usize>() };
+
+    // Find a pointer to the string in the .data section.
+    let step_name_ptr = &raw const *data_ptrs
+        .par_iter()
+        .find_any(|ptr| **ptr == step_name_ptr)
+        .ok_or_eyre("no matching step pointers")?;
+
+    // Replace the pointer to the step function before the string pointer with the one after it.
+    //
+    // Memory layout:
+    // 0x00 pointer to function TitleStep::STEP_BeginLogo  step_name_ptr.sub(1)
+    // 0x08 pointer to string "TitleStep::STEP_BeginLogo"  ↑↑↑
+    // 0x10 pointer to function TitleStep::STEP_BeginTitle step_name_ptr.add(1)
+    unsafe {
+        let prev_step_fn = step_name_ptr.sub(1) as *mut usize;
+        let next_step_fn = step_name_ptr.add(1).read();
+        prev_step_fn.write(next_step_fn);
+    }
+
+    Ok(())
+}
+
+/// Skip logos (Dark Souls 3 and Sekiro).
+fn skip_sprj_logos(exe: Executable) -> Result<(), eyre::Error> {
+    let [text, data] = pe::sections(exe, [".text", ".data"])
+        .map_err(|e| eyre!("PE section \"{e}\" is missing"))?;
+
+    let text = exe.get_section_bytes(text)?;
+    let data = exe.get_section_bytes(data)?;
+
+    // Matches:
+    // rex push rbp
+    // push   rsi
+    // push   rdi
+    // lea    rbp,[rsp+??]
+    // sub    rsp,??
+    // mov    QWORD PTR [rbp+??],-2
+    // mov    QWORD PTR [rsp+??],rbx
+    // mov    rdi,rcx
+    // mov    BYTE PTR [rip+??],0x1
+    let step_re = Regex::new(
+        r"(?s-u)\x40\x55\x56\x57\x48\x8d\x6c\x24.\x48\x81\xec.{4}\x48\xc7\x45.\xfe\xff\xff\xff\x48\x89\x9c\x24.{4}\x48\x8b\xf9\xc6\x05.{4}\x01",
+    )
+    .unwrap();
+
+    // Find the function in the .text section.
+    let step_ptr = step_re
+        .find(text)
+        .map(|m| m.as_bytes().as_ptr() as usize)
+        .ok_or_eyre("pattern returned no matches")?;
+
+    let (_, data_ptrs, _) = unsafe { data.align_to::<usize>() };
+
+    // Find a pointer to the function in the .data section.
+    let step_ptr = &raw const *data_ptrs
+        .par_iter()
+        .find_any(|ptr| **ptr == step_ptr)
+        .ok_or_eyre("no matching step pointers")?;
+
+    // Replace the pointer to the step function with the one after it.
+    //
+    // Memory layout:
+    // 0x00 pointer to function TitleStep::STEP_BeginLogo  step_ptr
+    // 0x08 ...                                            ↑↑↑
+    // 0x10 pointer to function TitleStep::STEP_BeginTitle step_ptr.add(2)
+    unsafe {
+        let next_step_fn = step_ptr.add(2).read();
+        ptr::write(step_ptr as *mut usize, next_step_fn);
+    }
+
+    Ok(())
+}
+
+/// Replaces the default WNDCLASSEXW white background color with black.
+fn fix_show_window_flash() -> Result<(), eyre::Error> {
+    unsafe {
+        let user32 = GetModuleHandleW(w!("user32.dll"))?;
+
+        let register_class = GetProcAddress(user32, s!("RegisterClassExW"))
+            .ok_or_eyre("RegisterClassExW not found")?;
+
+        ModHost::get_attached_mut()
+            .hook(mem::transmute::<
+                _,
+                unsafe extern "C" fn(*const WNDCLASSEXW) -> u16,
+            >(register_class))
+            .with_closure(|class, trampoline| {
+                if !class.is_null() {
+                    let mut class = class.read();
+                    class.hbrBackground = CreateSolidBrush(COLORREF(0));
+                    trampoline(&class)
+                } else {
+                    trampoline(class)
+                }
+            })
+            .install()?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Removed white screen when launching FromSoftware games.
- Added an option (on by default) to skip the logos shown on startup and when returning to the main menu. Use the `--show-logos` switch for `me3 launch` or the `skip_logos` key in "me3.toml" to override:
```toml
[game.eldenring]
skip_logos = false
```