### PR TITLE
feat: Publish Fedora RPMs via OBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ DESTDIR ?= out
 
 WINDOWS_TRIPLE ?= x86_64-pc-windows-msvc
 LINUX_TRIPLE ?= x86_64-unknown-linux-gnu
-SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct)
-COMMIT_ID=$(shell git rev-parse --verify HEAD)
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --format=%ct)
+COMMIT_ID ?= $(shell git rev-parse --verify HEAD)
 
 SIGNING_CERTIFICATE ?= releng/certificate.pem
 SIGNING_KEY ?= e25a03beabebbaa4b79fe76121540ec059794a60
@@ -33,6 +33,13 @@ clean:
 %.sig: %
 	rm -f $@
 	gpg -o $@ -b $<
+
+$(DESTDIR)/me3.spec: me3.spec.rpkg
+	rpkg spec -p > $(DESTDIR)/me3.spec
+
+$(DESTDIR)/me3-fedora-42-x86_64.rpm: $(DESTDIR)/me3.spec
+	rpkg srpm --outdir $(DESTDIR)
+	mock --enable-network -r fedora-42-x86_64 $(DESTDIR)/me3-$(shell rpmspec -q --qf '%{version}' $(DESTDIR)/me3.spec)-$(shell rpmspec -q --qf '%{release}' $(DESTDIR)/me3.spec).src.rpm
 
 $(DESTDIR)/%.pdf: %.md
 	pandoc -t html $< -o $@

--- a/me3.spec.rpkg
+++ b/me3.spec.rpkg
@@ -1,0 +1,69 @@
+%global debug_package %{nil}
+
+Name:       {{{ git_repo_name }}}
+Version:    {{{ git_repo_version }}}
+Release:    1%{?dist}
+Summary:    Modding framework for FROMSOFTWARE games
+
+License:    Apache-2.0 OR MIT
+URL:        https://me3.help
+VCS:        {{{ git_repo_vcs }}}
+
+Source0: {{{ git_dir_pack }}}
+Source1: vendor.tar.gz
+
+BuildRequires: rust-packaging
+BuildRequires: rust-std-static-x86_64-pc-windows-gnu
+BuildRequires: make
+BuildRequires: gcc
+BuildRequires: binutils
+BuildRequires: mingw64-binutils
+BuildRequires: mingw64-crt
+BuildRequires: mingw64-gcc
+BuildRequires: mingw64-libstdc++
+BuildRequires: mingw64-cpp
+BuildRequires: mingw64-headers
+BuildRequires: mingw64-filesystem
+BuildRequires: nasm
+BuildRequires: git
+BuildRequires: lld
+
+%description
+This is a test package.
+
+%prep
+{{{ git_repo_setup_macro source_indices=0,1 }}}
+cat > .cargo/config.toml <<EOF
+[build]
+target = "x86_64-pc-windows-gnu"
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source."git+https://github.com/Hpmason/retour-rs"]
+git = "https://github.com/Hpmason/retour-rs"
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "../vendor"
+EOF
+
+%build
+unset LDFLAGS CC CFLAGS RUSTFLAGS
+export RUSTFLAGS="-g"
+export SOURCE_DATE_EPOCH=0
+export RUSTC_BOOTSTRAP=1
+export WINDOWS_TRIPLE="x86_64-pc-windows-gnu"
+export COMMIT_ID="abc123"
+make out/me3 out/me3-launcher.exe out/me3_mod_host.dll
+	
+%install	
+install -Dpm 0755 -t "%{buildroot}%{_bindir}" out/me3
+install -Dpm 0755 -t "%{buildroot}%{_libdir}/me3/x86_64-windows" out/me3-launcher.exe out/me3_mod_host.dll
+
+%files	
+%{_bindir}/me3
+%{_libdir}/me3/x86_64-windows/me3-launcher.exe
+%{_libdir}/me3/x86_64-windows/me3_mod_host.dll
+
+%changelog


### PR DESCRIPTION
This is the first draft of Linux packages for me3. While this technically builds in mock without network access, it's quite a bit away from adhering to Fedora packaging guidelines.

Some unanswered questions:

- We ship linux-gnu binaries and windows-gnu binaries. Do we split the package into `me3` and `mingw64-me3-host`?
- How can we get the Cargo rpm macros working with the x86_64-pc-windows-gnu target?
- A lot of our dependencies are available in upstream Fedora repositories, can we avoid vendoring _everything_?