### PR TITLE
chore: Release v0.7.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,6 +21,7 @@ body:
       label: Version
       description: What version of our software are you running?
       options:
+        - v0.7.1
         - v0.7.0
         - prerelease
         - v0.6.1 (Latest)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 <!-- markdown-link-check-disable -->
 <!-- ignore lint rules that are often triggered by content generated from commits / git-cliff -->
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
+## me3 - [v0.7.1](https://github.com/garyttierney/me3/releases/v0.7.1) - 2025-08-10
+
+### 🐛 Bug Fixes
+
+- [39d7922](https://github.com/garyttierney/me3/commit/39d7922a6ee23c345f21166d3c8ab9331c812c0f) Unowned dirs in [#417](https://github.com/garyttierney/me3/pull/417)
+
+
+
+- [41f6b13](https://github.com/garyttierney/me3/commit/41f6b13f96412c6b1e4ee2572a82c0cb9ffcf2f9) Prepend to Windows PATH instead of append in [#396](https://github.com/garyttierney/me3/pull/396)
+
+
+  > A new path entry added by Windows seems to be interfering with PATH
+  > resolution. Prepend our path to the front of the list until Microsot
+  > deal with this.
+
+
+- [76eabf9](https://github.com/garyttierney/me3/commit/76eabf9fe79b579247eaeface9a550b00e43e62b) Missing nightreign-mods folder in Windows dist in [#392](https://github.com/garyttierney/me3/pull/392)
+
+
+
+### 📚 Documentation
+
+- [b62d3e2](https://github.com/garyttierney/me3/commit/b62d3e2ec6901c13b7378d07b0962fc0deacc090) Update docs for 0.7.0 in [#398](https://github.com/garyttierney/me3/pull/398)
+
+
+
+- [0da622c](https://github.com/garyttierney/me3/commit/0da622cb1aed670c21ae8c51d5bb81beaa6fcd5b) Add linkback to GitHub/bsky in [#393](https://github.com/garyttierney/me3/pull/393)
+
+
 ## me3 - [v0.7.0](https://github.com/garyttierney/me3/releases/v0.7.0) - 2025-07-28
 
 ### 🚀 Features
@@ -2330,6 +2359,7 @@ All notable changes to this project will be documented in this file.
 - [c4e6ef5](https://github.com/garyttierney/me3/commit/c4e6ef502776db75d89dbfef6c585b658a28caf4) Initial commit
 
 
+[0.7.1]: https://github.com/garyttierney/me3/compare/v0.7.0..v0.7.1
 [0.7.0]: https://github.com/garyttierney/me3/compare/v0.6.1..v0.7.0
 [0.6.1]: https://github.com/garyttierney/me3/compare/v0.6.0..v0.6.1
 [0.6.0]: https://github.com/garyttierney/me3/compare/v0.5.0..v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "me3-binary-analysis"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "pelite",
  "rayon",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_fs",
  "chrono",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "me3-env"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "crash-context",
  "dll-syringe",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bincode",
  "eyre",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "closure-ffi",
  "color-eyre",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cxx-stl",
  "from-singleton",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "expect-test",
  "schemars",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "color-eyre",
  "eyre",
@@ -4099,7 +4099,7 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xtask"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/binary-analysis/Cargo.toml
+++ b/crates/binary-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-binary-analysis"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-cli"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-env"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher-attach-protocol/Cargo.toml
+++ b/crates/launcher-attach-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher-attach-protocol"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-assets"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-protocol"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3_telemetry"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039  # local is non-POSIX
 set -u
 
-INSTALLER_VERSION=v0.7.0
+INSTALLER_VERSION=v0.7.1
 
 need_cmd() {
     if ! check_cmd "$1"; then


### PR DESCRIPTION

## [unreleased]

### 🐛 Bug Fixes

- [39d7922](https://github.com/garyttierney/me3/commit/39d7922a6ee23c345f21166d3c8ab9331c812c0f) Unowned dirs in [#417](https://github.com/garyttierney/me3/pull/417)



- [41f6b13](https://github.com/garyttierney/me3/commit/41f6b13f96412c6b1e4ee2572a82c0cb9ffcf2f9) Prepend to Windows PATH instead of append in [#396](https://github.com/garyttierney/me3/pull/396)


  > A new path entry added by Windows seems to be interfering with PATH
  > resolution. Prepend our path to the front of the list until Microsot
  > deal with this.


- [76eabf9](https://github.com/garyttierney/me3/commit/76eabf9fe79b579247eaeface9a550b00e43e62b) Missing nightreign-mods folder in Windows dist in [#392](https://github.com/garyttierney/me3/pull/392)



### 📚 Documentation

- [b62d3e2](https://github.com/garyttierney/me3/commit/b62d3e2ec6901c13b7378d07b0962fc0deacc090) Update docs for 0.7.0 in [#398](https://github.com/garyttierney/me3/pull/398)



- [0da622c](https://github.com/garyttierney/me3/commit/0da622cb1aed670c21ae8c51d5bb81beaa6fcd5b) Add linkback to GitHub/bsky in [#393](https://github.com/garyttierney/me3/pull/393)