### PR TITLE
fix: Prepend to Windows PATH instead of append

### DIFF
--- a/crates/cli/src/commands/windows.rs
+++ b/crates/cli/src/commands/windows.rs
@@ -35,7 +35,7 @@ pub fn add_to_path() -> color_eyre::Result<()> {
     }
 
     info!("current exe dir: {current_exe_dir}");
-    path_entries.push(&current_exe_dir);
+    path_entries.insert(0, &current_exe_dir);
 
     let new_path = path_entries.join(";");
     environment.set_value("Path", &new_path)?;


### PR DESCRIPTION
A new path entry added by Windows seems to be interfering with PATH
resolution. Prepend our path to the front of the list until Microsot
deal with this.

Signed-off-by: Gary Tierney <gary.tierney@fastmail.com>
