### PR TITLE
fix: Unowned dirs in rpm

### DIFF
--- a/me3.spec
+++ b/me3.spec
@@ -87,8 +87,7 @@ update-mime-database %{_datadir}/mime
 %license LICENSE-APACHE LICENSE-MIT
 %doc README.md
 %{_bindir}/me3
-%{_libdir}/me3/x86_64-windows/me3-launcher.exe
-%{_libdir}/me3/x86_64-windows/me3_mod_host.dll
+%{_libdir}/me3/
 %{_datadir}/applications/me3-launch.desktop
 %{_datadir}/mime/packages/me3.xml
 %{_datadir}/icons/hicolor/128x128/apps/me3.png


### PR DESCRIPTION
`/usr/lib64/me3` and `/usr/lib64/me3/x86_64-windows` were [unowned](https://docs.fedoraproject.org/en-US/packaging-guidelines/UnownedDirectories/), and would be left behind when uninstalling the rpm.

If this is too terse, it can also be written as:

```
%dir %{_libdir}/me3
%dir %{_libdir}/me3/x86_64-windows
%{_libdir}/me3/x86_64-windows/me3-launcher.exe
%{_libdir}/me3/x86_64-windows/me3_mod_host.dll
```