### PR TITLE
Clean up CLI help, add nicer wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -3231,6 +3232,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
  "rustix",
  "windows-sys 0.60.2",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,7 +17,7 @@ sentry = ["me3-telemetry/sentry"]
 
 [dependencies]
 chrono.workspace = true
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "wrap_help"] }
 color-eyre = { workspace = true, default-features = false, features = [
     "track-caller",
     "capture-spantrace",

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -17,7 +17,7 @@ pub enum Commands {
     Launch(LaunchArgs),
 
     /// Show information on the me3 installation and search paths.
-    #[clap(disable_version_flag = true)]
+    #[clap(disable_version_flag = true, disable_help_flag = true)]
     Info,
 
     #[clap(subcommand, disable_version_flag = true)]

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -12,7 +12,7 @@ pub mod windows;
 #[derive(Subcommand, Debug)]
 #[command(flatten_help = true)]
 pub enum Commands {
-    /// Launch the selected game a collection of mod profiles.
+    /// Launch the selected game with mods.
     Launch(LaunchArgs),
 
     /// Show information on the me3 installation and search paths.

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -13,12 +13,14 @@ pub mod windows;
 #[command(flatten_help = true)]
 pub enum Commands {
     /// Launch the selected game with mods.
+    #[clap(disable_version_flag = true)]
     Launch(LaunchArgs),
 
     /// Show information on the me3 installation and search paths.
+    #[clap(disable_version_flag = true)]
     Info,
 
-    #[clap(subcommand)]
+    #[clap(subcommand, disable_version_flag = true)]
     Profile(ProfileCommands),
 
     #[cfg(target_os = "windows")]

--- a/crates/cli/src/commands/info.rs
+++ b/crates/cli/src/commands/info.rs
@@ -23,19 +23,19 @@ pub fn info(config: Config) -> color_eyre::Result<()> {
     for (game, config) in &config.options.game {
         output.section(game.title(), |builder| {
             if let Some(boot_boost) = config.boot_boost {
-                builder.property("Boot Boost", boot_boost);
+                builder.property("Boot boost", boot_boost);
             }
 
             if let Some(skip_logos) = config.skip_logos {
-                builder.property("Skip startup logos?", skip_logos);
+                builder.property("Skip startup logos", skip_logos);
             }
 
             if let Some(skip_steam_init) = config.skip_steam_init {
-                builder.property("Skip Steam init?", format_status(skip_steam_init));
+                builder.property("Skip Steam init", format_status(skip_steam_init));
             }
 
             if let Some(exe) = &config.exe {
-                builder.property("Executable", exe.to_string_lossy());
+                builder.property("Custom executable", exe.to_string_lossy());
             }
         });
     }

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -66,7 +66,10 @@ pub struct Selector {
 
 #[derive(Args, Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
 pub struct GameOptions {
-    /// Don't cache decrypted BHD files (used for faster game startup)?
+    /// Don't cache decrypted BHD files?
+    ///
+    /// BHD archives are decrypted every time a game is started, which takes significant time and
+    /// CPU. me3 caches the decrypted archives to reduce game startup time.
     #[clap(long("no-boot-boost"), default_missing_value = "true", num_args=0..=1, value_parser = invert_bool())]
     pub(crate) boot_boost: Option<bool>,
 

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -128,7 +128,7 @@ pub struct LaunchArgs {
         )]
     profile: Option<String>,
 
-    /// Path to package directories that the mod host will use as VFS mount points.
+    /// Path to package directory (asset override mod) [repeatable option]
     #[arg(
             long("package"),
             action = clap::ArgAction::Append,
@@ -137,7 +137,7 @@ pub struct LaunchArgs {
         )]
     packages: Vec<PathBuf>,
 
-    /// Path to DLLs to be loaded by the mod host.
+    /// Path to DLL file (native DLL mod) [repeatable option]
     #[arg(
             short('n'),
             long("native"),

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -37,12 +37,12 @@ use crate::{
 #[derive(Debug, clap::Args)]
 #[group(multiple = false)]
 pub struct Selector {
-    /// Automatically detect the game to launch from mod profiles.
+    /// Detect the game to launch from mod profile.
     #[clap(long, help_heading = "Game selection", action = ArgAction::SetTrue, required = false)]
     auto_detect: bool,
 
-    /// Short name of a game to launch. The launcher will look for the the installation in
-    /// available Steam libraries.
+    /// Short name of a game to launch. The launcher will look for the game in available Steam
+    /// libraries.
     #[clap(
         short('g'),
         long,
@@ -53,8 +53,8 @@ pub struct Selector {
     #[arg(value_enum)]
     game: Option<Game>,
 
-    /// The Steam APPID of the game to launch. The launcher will attempt to find this app installed
-    /// in a Steam library and launch the configured command
+    /// Steam APPID of the game to launch. The launcher will look for this APPID in available Steam
+    /// libraries.
     #[clap(
         short('s'),
         long,
@@ -68,11 +68,11 @@ pub struct Selector {
 
 #[derive(Args, Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
 pub struct GameOptions {
-    /// Don't cache decrypted BHD files (used to improve game startup speed)?
+    /// Don't cache decrypted BHD files (used for faster game startup)?
     #[clap(long("no-boot-boost"), default_missing_value = "true", num_args=0..=1, value_parser = invert_bool())]
     pub(crate) boot_boost: Option<bool>,
 
-    /// Show the intro logos shown on every game launch?
+    /// Show game intro logos?
     #[clap(long("show-logos"), default_missing_value = "true", num_args=0..=1, value_parser = invert_bool())]
     pub(crate) skip_logos: Option<bool>,
 
@@ -80,8 +80,7 @@ pub struct GameOptions {
     #[clap(long("skip-steam-init"), default_missing_value = "true", num_args=0..=1)]
     pub(crate) skip_steam_init: Option<bool>,
 
-    /// An optional path to the game executable to launch with mod support. Uses the default
-    /// launcher if not present.
+    /// Custom path to the game executable.
     #[clap(short('e'), long, help_heading = "Game selection", value_hint = clap::ValueHint::FilePath)]
     pub(crate) exe: Option<PathBuf>,
 }
@@ -112,16 +111,15 @@ pub struct LaunchArgs {
     #[clap(flatten)]
     profile_options: ProfileOptions,
 
-    /// Enable diagnostics for this launch?
+    /// Enable diagnostics for this launch.
     #[clap(short('d'), long("diagnostics"), action = ArgAction::SetTrue)]
     diagnostics: bool,
 
-    /// Suspend the game until a debugger is attached?
+    /// Suspend the game until a debugger is attached.
     #[clap(long("suspend"), action = ArgAction::SetTrue)]
     suspend: bool,
 
-    /// Path to a ModProfile configuration file (TOML or JSON) or name of a profile
-    /// stored in the me3 profile folder ($XDG_CONFIG_HOME/me3).
+    /// Name of a profile in the me3 profile dir, or path to a ModProfile (TOML or JSON).
     #[arg(
             short('p'),
             long("profile"),

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -41,8 +41,7 @@ pub struct Selector {
     #[clap(long, help_heading = "Game selection", action = ArgAction::SetTrue, required = false)]
     auto_detect: bool,
 
-    /// Short name of a game to launch. The launcher will look for the game in available Steam
-    /// libraries.
+    /// Short name of a game to launch.
     #[clap(
         short('g'),
         long,
@@ -53,8 +52,7 @@ pub struct Selector {
     #[arg(value_enum)]
     game: Option<Game>,
 
-    /// Steam APPID of the game to launch. The launcher will look for this APPID in available Steam
-    /// libraries.
+    /// Steam APPID of the game to launch.
     #[clap(
         short('s'),
         long,

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -19,6 +19,7 @@ pub enum ProfileCommands {
     Create(ProfileCreateArgs),
 
     /// List profiles in the profile dir.
+    #[clap(disable_help_flag = true)]
     List,
 
     /// Show information on a profile.

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -71,11 +71,19 @@ pub struct ProfileCreateArgs {
 
 #[derive(Args, Clone, Debug, Default, PartialEq)]
 pub struct ProfileOptions {
-    /// Allow the game to connect to the multiplayer server?
+    /// Re-enable online matchmaking (ban risk)?
+    ///
+    /// Supported games are blocked from matchmaking servers by default to prevent accidental
+    /// online play with invalid (modded) data. Setting this option to true disables this
+    /// protection.
     #[clap(long("online"), default_missing_value = "true", num_args=0..=1)]
     pub start_online: Option<bool>,
 
-    /// Try to neutralize Arxan GuardIT code protection to improve mod stability?
+    /// Neutralize Arxan/GuardIT code protection?
+    ///
+    /// Arxan/GuardIT is a code tampering protection solution applied to most FromSoftware PC
+    /// games. Neutralizing it may help with stability of some mods that patch game executables and
+    /// allows for debugging the games without crashing.
     #[clap(long("disable-arxan"), default_missing_value = "true", num_args=0..=1)]
     pub disable_arxan: Option<bool>,
 }

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -15,13 +15,13 @@ use crate::{config::Config, db::DbContext, output::OutputBuilder, Game};
 #[derive(Subcommand, Debug)]
 #[command(flatten_help = true)]
 pub enum ProfileCommands {
-    /// Create a new profile with the given name.
+    /// Create a new ModProfile.
     Create(ProfileCreateArgs),
 
-    /// List all profiles stored in the ME3_PROFILE_DIR.
+    /// List profiles in the profile dir.
     List,
 
-    /// Show information on a profile identified by a name.
+    /// Show information on a profile.
     #[clap(name = "show")]
     Show { name: String },
 }
@@ -31,7 +31,7 @@ pub struct ProfileCreateArgs {
     /// Name of the profile.
     name: String,
 
-    /// An optional game to associate with this profile for one-click launches.
+    /// Game to associate with this profile for one-click launches.
     #[clap(
         short('g'),
         long,
@@ -56,12 +56,11 @@ pub struct ProfileCreateArgs {
     #[clap(flatten)]
     options: ProfileOptions,
 
-    /// Optional flag to treat the input as a filename instead of a profile ID to store in
-    /// ME3_PROFILE_DIR.
+    /// Treat NAME as a file path, instead of creating the profile in the profile dir.
     #[clap(short, long, action = ArgAction::SetTrue)]
     file: bool,
 
-    /// Overwrite the profile if it already exists
+    /// Overwrite the profile if it already exists.
     #[clap(long, action = ArgAction::SetTrue)]
     overwrite: bool,
 }

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -49,7 +49,7 @@ pub struct ProfileCreateArgs {
     packages: Vec<PathBuf>,
 
     /// Path to DLL file (native DLL mod) [repeatable option]
-    #[clap(long("native"))]
+    #[clap(short('n'), long("native"))]
     natives: Vec<PathBuf>,
 
     /// Name of an alternative savefile to use (in the default savefile directory).

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -41,11 +41,11 @@ pub struct ProfileCreateArgs {
     #[arg(value_enum)]
     game: Option<Game>,
 
-    /// Path to a list of packages to add to the profile.
+    /// Path to package directory (asset override mod) [repeatable option]
     #[clap(long("package"))]
     packages: Vec<PathBuf>,
 
-    /// Path to a list of native DLLs to add to the profile.
+    /// Path to DLL file (native DLL mod) [repeatable option]
     #[clap(long("native"))]
     natives: Vec<PathBuf>,
 

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -23,7 +23,10 @@ pub enum ProfileCommands {
 
     /// Show information on a profile.
     #[clap(name = "show")]
-    Show { name: String },
+    Show {
+        /// Name of the profile.
+        name: String,
+    },
 }
 
 #[derive(Args, Debug)]

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -30,11 +30,11 @@ pub struct Options {
     #[clap(long, help_heading = "Configuration", value_hint = clap::ValueHint::DirPath)]
     pub(crate) profile_dir: Option<Box<Path>>,
 
-    /// Optional path to a Steam installation, auto-detected if not provided
+    /// Use a different Steam installation than the one detected.
     #[clap(long, help_heading = "Configuration", value_hint = clap::ValueHint::DirPath)]
     pub(crate) steam_dir: Option<Box<Path>>,
 
-    /// Path to PE binaries used by Proton (Linux only)
+    /// Path to me3 Windows binaries for Proton (Linux only).
     #[clap(long, help_heading = "Configuration", value_hint = clap::ValueHint::DirPath)]
     pub(crate) windows_binaries_dir: Option<Box<Path>>,
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -17,9 +17,14 @@ pub mod db;
 pub mod output;
 
 #[derive(Parser)]
-#[command(name = "me3", version, about)]
-#[command(propagate_version = true)]
-#[command(flatten_help = true)]
+#[command(
+    name = "me3",
+    version,
+    about = "Mod loader for FROMSOFTWARE games",
+    after_help = "For more information, visit https://me3.help/",
+    propagate_version = true,
+    flatten_help = true
+)]
 struct Cli {
     #[clap(flatten)]
     config: Options,

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -33,7 +33,7 @@ fn run() -> LauncherResult<()> {
     if !config.skip_steam_init {
         require_steam(&args.exe)?;
     } else {
-        warn!("skpping steam initialization, no guarantee Steam game will launch successfully");
+        warn!("skipping Steam initialization, no guarantee Steam game will launch successfully");
     }
 
     let game_path = args.exe.parent();


### PR DESCRIPTION
Edited CLI help for typos, errors, length, language. There is now extended `--help` vs short `-h` for some options. Option descriptions wrap nicely based on terminal width.