### PR TITLE
feat: More anti-anti-debug features

### DIFF
--- a/crates/mod-host/src/debugger.rs
+++ b/crates/mod-host/src/debugger.rs
@@ -1,24 +1,69 @@
-use std::mem;
+use std::{
+    mem,
+    os::{raw::c_void, windows::raw::HANDLE},
+};
 
+use eyre::OptionExt;
 use windows::{
     core::{s, w},
-    Wdk::System::Threading::{NtQueryInformationProcess, PROCESSINFOCLASS},
-    Win32::System::{
-        Diagnostics::Debug::IsDebuggerPresent,
-        LibraryLoader::{GetModuleHandleW, GetProcAddress},
-        Threading::GetCurrentProcess,
+    Wdk::System::Threading::{
+        NtQueryInformationProcess, ThreadHideFromDebugger, PROCESSINFOCLASS, THREADINFOCLASS,
+    },
+    Win32::{
+        Foundation::{NTSTATUS, STATUS_SUCCESS},
+        System::{
+            Diagnostics::Debug::IsDebuggerPresent,
+            LibraryLoader::{GetModuleHandleW, GetProcAddress},
+            Threading::GetCurrentProcess,
+        },
     },
 };
 
-pub fn suspend_for_debugger() {
-    let is_debugger_present = if is_under_wine() {
-        is_wine_debugger_present
-    } else {
-        is_windows_debugger_present
-    };
+use crate::host::hook::HookInstaller;
 
+pub fn suspend_for_debugger() {
     while !is_debugger_present() {
         std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+pub fn prevent_hiding_threads() -> Result<(), eyre::Error> {
+    type NtSetInformationThread = unsafe extern "C" fn(
+        threadhandle: HANDLE,
+        threadinformationclass: THREADINFOCLASS,
+        threadinformation: *const c_void,
+        threadinformationlength: u32,
+    ) -> NTSTATUS;
+
+    let nt_set_information_thread = unsafe {
+        let ntdll = GetModuleHandleW(w!("ntdll.dll"))?;
+        mem::transmute::<_, NtSetInformationThread>(
+            GetProcAddress(ntdll, s!("NtSetInformationThread"))
+                .ok_or_eyre("NtSetInformationThread not found")?,
+        )
+    };
+
+    // Ignore ThreadHideFromDebugger calls to NtSetInformationThread.
+    let hook = HookInstaller::new(nt_set_information_thread)
+        .with_closure(|p1, threadinformationclass, p3, p4, trampoline| unsafe {
+            if threadinformationclass == ThreadHideFromDebugger {
+                return STATUS_SUCCESS;
+            }
+
+            trampoline(p1, threadinformationclass, p3, p4)
+        })
+        .install()?;
+
+    mem::forget(hook);
+
+    Ok(())
+}
+
+pub fn is_debugger_present() -> bool {
+    if is_under_wine() {
+        is_wine_debugger_present()
+    } else {
+        is_windows_debugger_present()
     }
 }
 


### PR DESCRIPTION
Address SteamStubDRM calling `NtSetInformationThread` with `ThreadHideFromDebugger` on the main thread (and block `ThreadHideFromDebugger` period)