### PR TITLE
refactor: Move `disable_arxan` to the mod profile

### DIFF
--- a/crates/cli/src/commands/info.rs
+++ b/crates/cli/src/commands/info.rs
@@ -30,10 +30,6 @@ pub fn info(config: Config) -> color_eyre::Result<()> {
                 builder.property("Skip startup logos?", skip_logos);
             }
 
-            if let Some(disable_arxan) = config.disable_arxan {
-                builder.property("Neutralize Arxan code protection", disable_arxan);
-            }
-
             if let Some(skip_steam_init) = config.skip_steam_init {
                 builder.property("Skip Steam init?", format_status(skip_steam_init));
             }

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -76,10 +76,6 @@ pub struct GameOptions {
     #[clap(long("show-logos"), default_missing_value = "true", num_args=0..=1, value_parser = invert_bool())]
     pub(crate) skip_logos: Option<bool>,
 
-    /// Try to neutralize Arxan GuardIT code protection to improve mod stability?
-    #[clap(long("disable-arxan"), default_missing_value = "true", num_args=0..=1)]
-    pub(crate) disable_arxan: Option<bool>,
-
     /// Skip initializing Steam within the launcher?
     #[clap(long("skip-steam-init"), default_missing_value = "true", num_args=0..=1)]
     pub(crate) skip_steam_init: Option<bool>,
@@ -99,7 +95,6 @@ impl GameOptions {
         Self {
             boot_boost: other.boot_boost.or(self.boot_boost),
             skip_logos: other.skip_logos.or(self.skip_logos),
-            disable_arxan: other.disable_arxan.or(self.disable_arxan),
             skip_steam_init: other.skip_steam_init.or(self.skip_steam_init),
             exe: other.exe.or(self.exe),
         }
@@ -373,7 +368,7 @@ impl LaunchArgs {
             boot_boost: opts.boot_boost.unwrap_or(true),
             skip_logos: opts.skip_logos.unwrap_or(true),
             start_online: profile_options.start_online.unwrap_or(false),
-            disable_arxan: opts.disable_arxan.unwrap_or(false),
+            disable_arxan: profile_options.disable_arxan.unwrap_or(false),
             skip_steam_init: opts.skip_steam_init.unwrap_or(false),
         })
     }
@@ -580,7 +575,6 @@ mod tests {
             GameOptions {
                 boot_boost: None,
                 skip_logos: None,
-                disable_arxan: None,
                 skip_steam_init: None,
                 exe: None,
             },
@@ -588,7 +582,10 @@ mod tests {
 
         pretty_assertions::assert_eq!(
             launch_args.profile_options,
-            ProfileOptions { start_online: None },
+            ProfileOptions {
+                start_online: None,
+                disable_arxan: None,
+            },
         );
     }
 
@@ -615,7 +612,6 @@ mod tests {
             GameOptions {
                 boot_boost: Some(false),
                 skip_logos: Some(false),
-                disable_arxan: Some(true),
                 skip_steam_init: Some(true),
                 exe: None,
             },
@@ -625,6 +621,7 @@ mod tests {
             launch_args.profile_options,
             ProfileOptions {
                 start_online: Some(true),
+                disable_arxan: Some(true),
             },
         );
     }
@@ -652,7 +649,6 @@ mod tests {
             GameOptions {
                 boot_boost: Some(true),
                 skip_logos: Some(true),
-                disable_arxan: Some(false),
                 skip_steam_init: Some(false),
                 exe: None,
             },
@@ -662,6 +658,7 @@ mod tests {
             launch_args.profile_options,
             ProfileOptions {
                 start_online: Some(false),
+                disable_arxan: Some(false),
             },
         );
     }
@@ -689,7 +686,6 @@ mod tests {
             GameOptions {
                 boot_boost: Some(false),
                 skip_logos: Some(false),
-                disable_arxan: Some(true),
                 skip_steam_init: Some(true),
                 exe: None,
             },
@@ -699,6 +695,7 @@ mod tests {
             launch_args.profile_options,
             ProfileOptions {
                 start_online: Some(true),
+                disable_arxan: Some(true),
             },
         );
     }

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -71,12 +71,21 @@ pub struct ProfileOptions {
     /// Allow the game to connect to the multiplayer server?
     #[clap(long("online"), default_missing_value = "true", num_args=0..=1)]
     pub start_online: Option<bool>,
+
+    /// Try to neutralize Arxan GuardIT code protection to improve mod stability?
+    #[clap(long("disable-arxan"), default_missing_value = "true", num_args=0..=1)]
+    pub disable_arxan: Option<bool>,
 }
 
 impl ProfileOptions {
     pub fn merge(self, other: Self) -> Self {
         Self {
             start_online: other.start_online.or(self.start_online),
+            disable_arxan: match (other.disable_arxan, self.disable_arxan) {
+                (Some(true), _) => Some(true),
+                (_, Some(true)) => Some(true),
+                (a, b) => a.or(b),
+            },
         }
     }
 }
@@ -199,6 +208,7 @@ pub fn show(db: DbContext, name: String) -> color_eyre::Result<()> {
 
         let options = profile.options();
         builder.property("Start Online", opt_to_str(options.start_online));
+        builder.property("Neutralize Arxan", opt_to_str(options.disable_arxan));
     });
 
     println!("{}", output.build());

--- a/crates/cli/src/db/profile.rs
+++ b/crates/cli/src/db/profile.rs
@@ -85,6 +85,7 @@ impl Profile {
     pub fn options(&self) -> ProfileOptions {
         ProfileOptions {
             start_online: self.profile.start_online(),
+            disable_arxan: self.profile.disable_arxan(),
         }
     }
 

--- a/crates/mod-protocol/src/lib.rs
+++ b/crates/mod-protocol/src/lib.rs
@@ -103,6 +103,12 @@ impl ModProfile {
             ModProfile::V1(v1) => v1.start_online,
         }
     }
+
+    pub fn disable_arxan(&self) -> Option<bool> {
+        match self {
+            ModProfile::V1(v1) => v1.disable_arxan,
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema)]
@@ -129,6 +135,10 @@ pub struct ModProfileV1 {
     /// Starts the game with multiplayer server connectivity enabled.
     #[serde(default)]
     start_online: Option<bool>,
+
+    /// Try to neutralize Arxan GuardIT code protection to improve mod stability.
+    #[serde(default)]
+    disable_arxan: Option<bool>,
 }
 
 #[cfg(test)]

--- a/crates/mod-protocol/test-data/basic_config.me3.toml.expected
+++ b/crates/mod-protocol/test-data/basic_config.me3.toml.expected
@@ -29,5 +29,6 @@ V1(
         ],
         savefile: None,
         start_online: None,
+        disable_arxan: None,
     },
 )

--- a/crates/mod-protocol/test-data/plural_packages.me3.expected
+++ b/crates/mod-protocol/test-data/plural_packages.me3.expected
@@ -17,5 +17,6 @@ V1(
         ],
         savefile: None,
         start_online: None,
+        disable_arxan: None,
     },
 )

--- a/crates/mod-protocol/test-data/singular_package.me3.expected
+++ b/crates/mod-protocol/test-data/singular_package.me3.expected
@@ -17,5 +17,6 @@ V1(
         ],
         savefile: None,
         start_online: None,
+        disable_arxan: None,
     },
 )

--- a/schemas/mod-profile.json
+++ b/schemas/mod-profile.json
@@ -87,6 +87,14 @@
     "ModProfileV1": {
       "type": "object",
       "properties": {
+        "disable_arxan": {
+          "description": "Try to neutralize Arxan GuardIT code protection to improve mod stability.",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
         "natives": {
           "description": "Native modules (DLLs) that will be loaded.",
           "type": "array",


### PR DESCRIPTION
Introduces a special behavior for `disable_arxan`, making it required if either the mod profile or the command line requires it.