### PR TITLE
fix(linux): Support proper compatibility tool lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ dependencies = [
  "ctrlc",
  "directories",
  "is-terminal",
+ "keyvalues-serde",
  "me3-env",
  "me3-launcher-attach-protocol",
  "me3-mod-protocol",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,6 +25,7 @@ color-eyre = { workspace = true, default-features = false, features = [
 ctrlc.workspace = true
 directories.workspace = true
 is-terminal.workspace = true
+keyvalues-serde = "0.2.2"
 me3-env.workspace = true
 me3-launcher-attach-protocol.workspace = true
 me3-mod-protocol.workspace = true

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -1,3 +1,5 @@
+pub mod proton;
+
 use std::{
     error::Error,
     fmt::Debug,
@@ -28,7 +30,7 @@ use tempfile::NamedTempFile;
 use tracing::{error, info};
 
 use crate::{
-    commands::profile::ProfileOptions,
+    commands::{launch::proton::CompatTools, profile::ProfileOptions},
     config::Config,
     db::{profile::Profile, DbContext},
     Game,
@@ -183,38 +185,17 @@ impl Launcher for CompatToolLauncher {
             .find_app(sniper_id)?
             .ok_or_eyre("unable to find Steam Linux Runtime")?;
 
-        let tool_name = self.tool.name.ok_or_eyre("compat tool must have a name")?;
-        let custom_tool_path = self
-            .steam
-            .path()
-            .join(format!("compatibilitytools.d/{tool_name}"));
-
-        let proton_path = if std::fs::exists(&custom_tool_path)? {
-            custom_tool_path
-        } else {
-            let proton_id = match tool_name.as_str() {
-                "proton_experimental" => 1493710,
-                "proton_hotfix" => 2180100,
-                "proton_9" => 2805730,
-                _ => return Err(eyre!("unrecognised compat tool")),
-            };
-
-            let (proton_app, proton_library) = self
-                .steam
-                .find_app(proton_id)?
-                .ok_or_eyre("configured compat tool isn't installed")?;
-
-            proton_library.resolve_app_dir(&proton_app)
-        };
-
+        let compat_tools = CompatTools::new(&self.steam);
+        let compat_tool = compat_tools
+            .find(self.tool.name.expect("compat tools must be named"))
+            .ok_or_eyre("unable to find compatibility tool installation")?;
         let sniper_path = sniper_library.resolve_app_dir(&sniper_app);
-
         let mut command = Command::new(sniper_path.join("run"));
 
         command.args([
             "--batch",
             "--",
-            &*proton_path.join("proton").to_string_lossy(),
+            &*compat_tool.install_path.join("proton").to_string_lossy(),
             "waitforexitandrun",
             &*launcher.to_string_lossy(),
         ]);

--- a/crates/cli/src/commands/launch/proton.rs
+++ b/crates/cli/src/commands/launch/proton.rs
@@ -112,7 +112,7 @@ pub enum CompatToolLoadError {
     TooManyEntries,
 
     #[error("failed to parse vdf")]
-    ParseError(#[from] keyvalues_serde::Error),
+    ParseError(#[from] Box<keyvalues_serde::Error>),
 
     #[error("unexpected IO error: {inner}")]
     Other {
@@ -126,7 +126,7 @@ impl CompatTool {
         let vdf_path = path.as_ref();
         let file = File::open(vdf_path)?;
 
-        let mut vdf: CompatToolVdf = keyvalues_serde::from_reader(file)?;
+        let mut vdf: CompatToolVdf = keyvalues_serde::from_reader(file).map_err(Box::from)?;
         if vdf.compat_tools.len() > 1 {
             return Err(CompatToolLoadError::TooManyEntries);
         }

--- a/crates/cli/src/commands/launch/proton.rs
+++ b/crates/cli/src/commands/launch/proton.rs
@@ -1,0 +1,184 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use normpath::PathExt;
+use serde::Deserialize;
+use steamlocate::SteamDir;
+use tracing::info;
+
+pub struct CompatTools<'a> {
+    steam: &'a SteamDir,
+    search_paths: Vec<Box<Path>>,
+}
+
+impl<'a> CompatTools<'a> {
+    pub fn new(steamdir: &'a SteamDir) -> Self {
+        let mut search_paths = vec![
+            Box::from(Path::new("/usr/share/steam/compatibilitytools.d")),
+            Box::from(Path::new("/usr/local/share/steam/compatibilitytools.d")),
+        ];
+
+        let extra_search_paths = std::env::var("STEAM_EXTRA_COMPAT_TOOLS_PATHS")
+            .into_iter()
+            .flat_map(|paths| {
+                paths
+                    .split(':')
+                    .map(|path| Box::from(Path::new(path)))
+                    .collect::<Vec<_>>()
+            });
+
+        search_paths.extend(extra_search_paths);
+        search_paths.push(
+            steamdir
+                .path()
+                .join("compatibilitytools.d")
+                .into_boxed_path(),
+        );
+
+        Self {
+            steam: steamdir,
+            search_paths,
+        }
+    }
+
+    pub fn all(&self) -> impl Iterator<Item = CompatTool> {
+        self.search_paths.iter().flat_map(|path| {
+            std::fs::read_dir(path)
+                .into_iter()
+                .flatten()
+                .filter_map(|entry| {
+                    let dir = entry.ok()?;
+                    let manifest_path = dir.path().join("compatibilitytool.vdf");
+
+                    manifest_path.exists().then_some(manifest_path)
+                })
+                .flat_map(CompatTool::load)
+        })
+    }
+
+    pub fn find(&self, name: impl AsRef<str>) -> Option<CompatTool> {
+        let name = name.as_ref();
+        let tool_appid = match name {
+            "proton_experimental" => 1493710,
+            "proton_hotfix" => 2180100,
+            "proton_9" => 2805730,
+            name => {
+                let tools = CompatTools::new(self.steam);
+                let installations = tools.all();
+
+                return installations
+                    .filter(|tool| tool.name == name)
+                    .inspect(|tool| info!(path=?tool.install_path, "found compat tool"))
+                    .last();
+            }
+        };
+
+        let (tool_app, tool_library) = self.steam.find_app(tool_appid).ok().flatten()?;
+        let tool_dir = tool_library.resolve_app_dir(&tool_app);
+
+        Some(CompatTool {
+            name: name.to_string(),
+            display_name: name.to_string(),
+            install_path: tool_dir.into(),
+        })
+    }
+}
+
+pub struct CompatTool {
+    pub name: String,
+    pub display_name: String,
+    pub install_path: Box<Path>,
+}
+
+impl CompatTool {
+    pub fn manifest(&self) -> color_eyre::Result<CompatToolManifest> {
+        let path = self.install_path.join("toolmanifest.vdf");
+        let file = File::open(path)?;
+        let manifest: CompatToolManifest = keyvalues_serde::from_reader(file)?;
+
+        Ok(manifest)
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CompatToolLoadError {
+    #[error("compatibilitytool.vdf contains no compat tool entry")]
+    NoEntry,
+
+    #[error("compatibilitytool.vdf contains multiple entries")]
+    TooManyEntries,
+
+    #[error("failed to parse vdf")]
+    ParseError(#[from] keyvalues_serde::Error),
+
+    #[error("unexpected IO error: {inner}")]
+    Other {
+        #[from]
+        inner: std::io::Error,
+    },
+}
+
+impl CompatTool {
+    pub fn load(path: impl AsRef<Path>) -> color_eyre::Result<Self, CompatToolLoadError> {
+        let vdf_path = path.as_ref();
+        let file = File::open(vdf_path)?;
+
+        let mut vdf: CompatToolVdf = keyvalues_serde::from_reader(file)?;
+        if vdf.compat_tools.len() > 1 {
+            return Err(CompatToolLoadError::TooManyEntries);
+        }
+
+        let (name, info) = vdf
+            .compat_tools
+            .drain()
+            .next()
+            .ok_or(CompatToolLoadError::NoEntry)?;
+
+        let display_name = info.display_name;
+        let install_path = if info.install_path.is_absolute() {
+            info.install_path
+        } else {
+            vdf_path
+                .parent()
+                .ok_or(std::io::Error::other("parent folder disappeared"))?
+                .normalize()?
+                .join(info.install_path)
+                .into_path_buf()
+        };
+
+        Ok(CompatTool {
+            name,
+            display_name,
+            install_path: install_path.into_boxed_path(),
+        })
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
+struct CompatToolVdf {
+    pub compat_tools: HashMap<String, CompatToolInfo>,
+}
+
+#[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
+
+struct CompatToolInfo {
+    install_path: PathBuf,
+    display_name: String,
+    from_oslist: String,
+    to_oslist: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub struct CompatToolManifest {
+    version: u32,
+    commandline: String,
+    require_tool_app_id: u32,
+    use_sessions: bool,
+    compatmanager_layer_name: String,
+}

--- a/crates/cli/src/commands/launch/proton.rs
+++ b/crates/cli/src/commands/launch/proton.rs
@@ -165,7 +165,6 @@ struct CompatToolVdf {
 
 #[derive(Deserialize, Debug)]
 #[cfg_attr(test, derive(serde::Serialize))]
-
 struct CompatToolInfo {
     install_path: PathBuf,
     display_name: String,

--- a/crates/mod-host/src/lib.rs
+++ b/crates/mod-host/src/lib.rs
@@ -200,8 +200,8 @@ pub extern "system" fn DllMain(instance: usize, reason: u32, _: *mut usize) -> i
                 __llvm_profile_write_file()
             };
 
-            // FIXME: this panics on process exit, either on thread creation or accessing a thread local.
-            // Ideally, it should be called at an earlier point.
+            // FIXME: this panics on process exit, either on thread creation or accessing a thread
+            // local. Ideally, it should be called at an earlier point.
             //
             // The crash handler (when re-added) should call flush instead.
             //


### PR DESCRIPTION
All valid directories that can contain a compatibilitytool.vdf file are now queried for a manifest matching the tool we're interested in. Additionally, we also check the actual name contained in the manifest instead of relying on the name of the directory.

Fixes #425, #426