### PR TITLE
fix: Consistent native and package load order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,9 +1336,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1628,7 +1628,7 @@ dependencies = [
  "strum",
  "tempfile",
  "thiserror 2.0.16",
- "toml",
+ "toml 0.9.5",
  "tracing",
  "ureq",
  "windows",
@@ -1658,7 +1658,7 @@ dependencies = [
  "me3_telemetry",
  "minidump-writer",
  "sentry",
- "toml",
+ "toml 0.9.5",
  "tracing",
  "windows",
  "winresource",
@@ -1749,14 +1749,14 @@ name = "me3-mod-protocol"
 version = "0.7.0"
 dependencies = [
  "expect-test",
+ "indexmap",
  "schemars",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
  "thiserror 2.0.16",
- "toml",
- "topological-sort",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -2955,6 +2955,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2966,6 +2967,15 @@ name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -3381,9 +3391,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3396,6 +3421,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3403,9 +3437,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
  "winnow",
 ]
 
@@ -3416,10 +3459,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
-name = "topological-sort"
-version = "0.2.2"
+name = "toml_writer"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tracing"
@@ -4164,7 +4207,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcacf11b6f48dd21b9ba002f991bdd5de29b2da8cc2800412f4b80f677e4957"
 dependencies = [
- "toml",
+ "toml 0.8.23",
  "version_check",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ strum = "0.27"
 strum_macros = "0.27"
 tempfile = "3"
 thiserror = "2"
-toml = "0.8"
+toml = { version = "0.9.5", features = ["preserve_order"] }
 tracing = { version = "0.1", features = ["release_max_level_info"] }
 tracing-appender = "0.2"
 tracing-error = "0.2"

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -9,14 +9,14 @@ description = "Schema definition for me3 mod profiles"
 publish = false
 
 [dependencies]
+indexmap = "2.11.0"
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
 strum.workspace = true
 strum_macros.workspace = true
 toml.workspace = true
 thiserror.workspace = true
-topological-sort = "0.2.2"
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/crates/mod-protocol/src/dependency.rs
+++ b/crates/mod-protocol/src/dependency.rs
@@ -164,7 +164,7 @@ impl<T> PartialEq for DependencyRun<T> {
 
 impl<T> PartialOrd for DependencyRun<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        other.max_index.partial_cmp(&self.max_index)
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/mod-protocol/src/dependency.rs
+++ b/crates/mod-protocol/src/dependency.rs
@@ -1,11 +1,11 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BinaryHeap, HashSet},
     hash::{Hash, RandomState},
 };
 
+use indexmap::{map::Entry, IndexMap};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use topological_sort::TopologicalSort;
 
 pub trait DependencyId: Eq + PartialEq + Hash + Clone {}
 impl<T: Eq + PartialEq + Hash + Clone + for<'de> Deserialize<'de> + Serialize> DependencyId for T {}
@@ -67,49 +67,175 @@ pub enum DependencyError<T: Dependency> {
     Cyclic(Vec<T::UniqueId>),
 }
 
-pub fn sort_dependencies<T: Dependency>(items: Vec<T>) -> Result<Vec<T>, DependencyError<T>> {
-    let mut sorter = TopologicalSort::<T::UniqueId>::new();
-    let mut all = HashMap::new();
-    all.extend(items.into_iter().map(|item| (item.id(), item)));
+#[derive(Clone)]
+struct DependencyNode<T> {
+    num_prec: usize,
+    succ: HashSet<T>,
+}
 
-    for item in all.values() {
+impl<T> DependencyNode<T> {
+    fn new() -> Self {
+        Self {
+            num_prec: 0,
+            succ: HashSet::new(),
+        }
+    }
+}
+
+trait DependencySorter {
+    type UniqueId: DependencyId;
+
+    fn add_dependency(&mut self, prec: Self::UniqueId, succ: Self::UniqueId);
+    fn pop_dependency(&mut self) -> Option<(Self::UniqueId, bool)>;
+}
+
+// <https://crates.io/crates/topological-sort>
+impl<T> DependencySorter for IndexMap<T, DependencyNode<T>>
+where
+    T: DependencyId + Clone,
+{
+    type UniqueId = T;
+
+    fn add_dependency(&mut self, prec: T, succ: T) {
+        match self.entry(prec) {
+            Entry::Vacant(e) => {
+                let mut dep = DependencyNode::new();
+                dep.succ.insert(succ.clone());
+                e.insert(dep);
+            }
+            Entry::Occupied(e) => {
+                if !e.into_mut().succ.insert(succ.clone()) {
+                    // Already registered
+                    return;
+                }
+            }
+        }
+
+        match self.entry(succ) {
+            Entry::Vacant(e) => {
+                let mut dep = DependencyNode::new();
+                dep.num_prec += 1;
+                e.insert(dep);
+            }
+            Entry::Occupied(e) => {
+                e.into_mut().num_prec += 1;
+            }
+        }
+    }
+
+    fn pop_dependency(&mut self) -> Option<(T, bool)> {
+        self.iter()
+            .find_map(|(k, v)| (v.num_prec == 0).then_some(k.clone()))
+            .map(|key| {
+                if let Some(p) = self.shift_remove(&key) {
+                    for s in &p.succ {
+                        if let Some(y) = self.get_mut(s) {
+                            y.num_prec -= 1;
+                        }
+                    }
+
+                    (key, !p.succ.is_empty())
+                } else {
+                    (key, false)
+                }
+            })
+    }
+}
+
+struct DependencyRun<T> {
+    max_index: usize,
+    dependencies: Vec<T>,
+}
+
+impl<T> Default for DependencyRun<T> {
+    fn default() -> Self {
+        Self {
+            max_index: 0,
+            dependencies: vec![],
+        }
+    }
+}
+
+impl<T> PartialEq for DependencyRun<T> {
+    fn eq(&self, other: &Self) -> bool {
+        other.max_index.eq(&self.max_index)
+    }
+}
+
+impl<T> PartialOrd for DependencyRun<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        other.max_index.partial_cmp(&self.max_index)
+    }
+}
+
+impl<T> Eq for DependencyRun<T> {}
+
+impl<T> Ord for DependencyRun<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other.max_index.cmp(&self.max_index)
+    }
+}
+
+pub fn sort_dependencies<T: Dependency>(items: Vec<T>) -> Result<Vec<T>, DependencyError<T>> {
+    let mut sorter = IndexMap::<T::UniqueId, DependencyNode<T::UniqueId>>::new();
+    let mut all = items
+        .into_iter()
+        .enumerate()
+        .map(|(index, item)| (item.id(), (item, index)))
+        .collect::<IndexMap<_, _, RandomState>>();
+
+    for (id, (item, _)) in &all {
         for dep in item.dependencies() {
             if !all.contains_key(&dep.id) {
                 if !dep.optional {
                     return Err(DependencyError::MissingDependency(dep.id.clone()));
                 }
-
                 continue;
             }
 
             let (prec, succ) = match dep.order {
-                DependencyOrder::Before => (item.id(), dep.id),
-                DependencyOrder::After => (dep.id, item.id()),
+                DependencyOrder::Before => (id.clone(), dep.id),
+                DependencyOrder::After => (dep.id, id.clone()),
             };
 
             sorter.add_dependency(prec, succ)
         }
     }
 
-    let mut remaining: HashSet<_, RandomState> = HashSet::from_iter(all.keys().cloned());
-    let mut sorted = vec![];
+    let mut all_runs = BinaryHeap::new();
+    let mut current_run = DependencyRun::<T>::default();
 
-    while let Some(key) = sorter.pop() {
-        let item = all.remove(&key).expect("item already removed?");
+    let mut max_index = None;
 
-        sorted.push(item);
-        remaining.remove(&key);
+    while let Some((key, has_succ)) = sorter.pop_dependency() {
+        let (item, index) = all.shift_remove(&key).expect("item already removed?");
+
+        if max_index.is_none() && item.loads_after().is_empty() && item.loads_before().is_empty() {
+            max_index = Some(index);
+        }
+
+        current_run.dependencies.push(item);
+
+        if !has_succ {
+            current_run.max_index = max_index.take().unwrap_or(index);
+            all_runs.push(std::mem::take(&mut current_run));
+        }
     }
 
     if !sorter.is_empty() {
-        return Err(DependencyError::Cyclic(remaining.into_iter().collect()));
+        return Err(DependencyError::Cyclic(all.keys().cloned().collect()));
     }
 
-    sorted.extend(
-        remaining
-            .into_iter()
-            .map(|key| all.remove(&key).expect("item already removed?")),
-    );
+    let mut sorted = vec![];
+
+    for (item, index) in all.into_values() {
+        if all_runs.peek().is_some_and(|run| run.max_index < index) {
+            sorted.extend(all_runs.pop().unwrap().dependencies);
+        }
+        sorted.push(item);
+    }
+
+    sorted.extend(all_runs.into_iter().flat_map(|run| run.dependencies));
 
     Ok(sorted)
 }
@@ -217,5 +343,36 @@ mod tests {
         let pkg3 = mock_package("pkg3", vec![], vec![]);
 
         sort_dependencies(vec![pkg1, pkg2, pkg3]).expect("failed to sort");
+    }
+
+    #[test]
+    fn preserves_iteration_order() {
+        let pkg1 = mock_package("pkg1", vec![], vec![]);
+        let pkg2 = mock_package("pkg2", vec![], vec![]);
+        let pkg3 = mock_package(
+            "pkg3",
+            vec![],
+            vec![Dependent {
+                id: "pkg2".to_owned(),
+                optional: false,
+            }],
+        );
+        let pkg4 = mock_package(
+            "pkg4",
+            vec![],
+            vec![Dependent {
+                id: "pkg2".to_owned(),
+                optional: false,
+            }],
+        );
+        let pkg5 = mock_package("pkg5", vec![], vec![]);
+
+        let sorted = sort_dependencies(vec![pkg1, pkg2, pkg3, pkg4, pkg5]).unwrap();
+
+        assert_eq!("pkg1", sorted[0].id());
+        assert_eq!("pkg3", sorted[1].id());
+        assert_eq!("pkg4", sorted[2].id());
+        assert_eq!("pkg2", sorted[3].id());
+        assert_eq!("pkg5", sorted[4].id());
     }
 }

--- a/schemas/mod-profile.json
+++ b/schemas/mod-profile.json
@@ -17,19 +17,21 @@
     }
   ],
   "$defs": {
-    "Dependent": {
+    "Supports": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "game": {
+          "$ref": "#/$defs/Game"
         },
-        "optional": {
-          "type": "boolean"
+        "since": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "id",
-        "optional"
+        "game"
       ]
     },
     "Game": {
@@ -80,77 +82,36 @@
         }
       ]
     },
-    "ModFile": {
-      "description": "A filesystem path to the contents of a package. May be relative to the [ModProfile] containing\nit.",
-      "type": "string"
-    },
-    "ModProfileV1": {
-      "type": "object",
-      "properties": {
-        "disable_arxan": {
-          "description": "Try to neutralize Arxan GuardIT code protection to improve mod stability.",
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null
-        },
-        "natives": {
-          "description": "Native modules (DLLs) that will be loaded.",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/Native"
-          }
-        },
-        "packages": {
-          "description": "A collection of packages containing assets that should be considered for loading\nbefore the DVDBND.",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/Package"
-          }
-        },
-        "savefile": {
-          "description": "Name of an alternative savefile to use (in the default savefile directory).",
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null
-        },
-        "start_online": {
-          "description": "Starts the game with multiplayer server connectivity enabled.",
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null
-        },
-        "supports": {
-          "description": "The games that this profile supports.",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/Supports"
-          }
-        }
-      }
-    },
     "Native": {
       "type": "object",
       "properties": {
+        "path": {
+          "description": "Path to the DLL. Can be relative to the mod profile.",
+          "$ref": "#/$defs/ModFile"
+        },
+        "optional": {
+          "description": "If this native fails to load and this value is false, treat it as a critical error.",
+          "type": "boolean",
+          "default": false
+        },
         "enabled": {
           "description": "Should this native be loaded?",
           "type": "boolean",
           "default": true
         },
-        "finalizer": {
-          "description": "An optional symbol to be called when this native successfully is queued for unload.",
-          "type": [
-            "string",
-            "null"
-          ]
+        "load_before": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Dependent"
+          },
+          "default": []
+        },
+        "load_after": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Dependent"
+          },
+          "default": []
         },
         "initializer": {
           "description": "An optional symbol to be called after this native successfully loads.",
@@ -163,32 +124,35 @@
             }
           ]
         },
-        "load_after": {
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/Dependent"
-          }
-        },
-        "load_before": {
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/Dependent"
-          }
-        },
-        "optional": {
-          "description": "If this native fails to load and this value is false, treat it as a critical error.",
-          "type": "boolean",
-          "default": false
-        },
-        "path": {
-          "description": "Path to the DLL. Can be relative to the mod profile.",
-          "$ref": "#/$defs/ModFile"
+        "finalizer": {
+          "description": "An optional symbol to be called when this native successfully is queued for unload.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "path"
+      ]
+    },
+    "ModFile": {
+      "description": "A filesystem path to the contents of a package. May be relative to the [ModProfile] containing\nit.",
+      "type": "string"
+    },
+    "Dependent": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "optional"
       ]
     },
     "NativeInitializerCondition": {
@@ -210,10 +174,10 @@
               ]
             }
           },
-          "additionalProperties": false,
           "required": [
             "delay"
-          ]
+          ],
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -222,10 +186,10 @@
               "type": "string"
             }
           },
-          "additionalProperties": false,
           "required": [
             "function"
-          ]
+          ],
+          "additionalProperties": false
         }
       ]
     },
@@ -233,11 +197,6 @@
       "description": "A package is a source for files that override files within the existing games DVDBND archives.\nIt points to a local path containing assets matching the hierarchy they would be served under in\nthe DVDBND.",
       "type": "object",
       "properties": {
-        "enabled": {
-          "description": "Enable this package?",
-          "type": "boolean",
-          "default": true
-        },
         "id": {
           "description": "The unique identifier for this package.",
           "type": [
@@ -245,47 +204,88 @@
             "null"
           ]
         },
-        "load_after": {
-          "description": "A list of package IDs that this package should load after.",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/Dependent"
-          }
-        },
-        "load_before": {
-          "description": "A list of packages that this package should load before.",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/Dependent"
-          }
+        "enabled": {
+          "description": "Enable this package?",
+          "type": "boolean",
+          "default": true
         },
         "path": {
           "description": "A path to the source of this package.",
           "$ref": "#/$defs/ModFile"
+        },
+        "load_after": {
+          "description": "A list of package IDs that this package should load after.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Dependent"
+          },
+          "default": []
+        },
+        "load_before": {
+          "description": "A list of packages that this package should load before.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Dependent"
+          },
+          "default": []
         }
       },
       "required": [
         "path"
       ]
     },
-    "Supports": {
+    "ModProfileV1": {
       "type": "object",
       "properties": {
-        "game": {
-          "$ref": "#/$defs/Game"
+        "supports": {
+          "description": "The games that this profile supports.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Supports"
+          },
+          "default": []
         },
-        "since": {
+        "natives": {
+          "description": "Native modules (DLLs) that will be loaded.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Native"
+          },
+          "default": []
+        },
+        "packages": {
+          "description": "A collection of packages containing assets that should be considered for loading\nbefore the DVDBND.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Package"
+          },
+          "default": []
+        },
+        "savefile": {
+          "description": "Name of an alternative savefile to use (in the default savefile directory).",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
+        },
+        "start_online": {
+          "description": "Starts the game with multiplayer server connectivity enabled.",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "disable_arxan": {
+          "description": "Try to neutralize Arxan GuardIT code protection to improve mod stability.",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
         }
-      },
-      "required": [
-        "game"
-      ]
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes a bug where profiles with multiple packages and natives did not have a deterministic load order without using the `load_before`/`load_after` keys.