### PR TITLE
fix(cli): Profile improvements

### DIFF
--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -146,17 +146,7 @@ pub fn create(config: Config, args: ProfileCreateArgs) -> color_eyre::Result<()>
 
     let packages = profile.packages_mut();
     for pkg in args.packages {
-        let full_path = if pkg.is_absolute() || std::fs::exists(&pkg)? {
-            pkg
-        } else {
-            profile_dir.join(pkg)
-        };
-
-        if !std::fs::exists(&full_path)? {
-            std::fs::create_dir_all(&full_path)?;
-        }
-
-        packages.push(Package::new(full_path));
+        packages.push(Package::new(pkg));
     }
 
     let natives = profile.natives_mut();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
         Commands::Launch(args) => commands::launch::launch(db, config, args),
         Commands::Profile(ProfileCommands::Create(args)) => commands::profile::create(config, args),
         Commands::Profile(ProfileCommands::List) => commands::profile::list(db),
-        Commands::Profile(ProfileCommands::Show { name }) => commands::profile::show(db, name),
+        Commands::Profile(ProfileCommands::Show(name)) => commands::profile::show(db, config, name),
         #[cfg(target_os = "windows")]
         Commands::AddToPath => commands::windows::add_to_path(),
         #[cfg(target_os = "windows")]

--- a/installer.nsi
+++ b/installer.nsi
@@ -194,6 +194,9 @@ Section "Main Application" SEC01
     WriteRegStr HKCU "Software\${PRODUCT}" "Install_Dir" $INSTDIR
     nsExec::Exec '"$INSTDIR\bin\me3.exe" add-to-path'
 
+    CreateDirectory "$LOCALAPPDATA\garyttierney\me3\config\profiles\darksouls3-mods"
+    nsExec::Exec '"$INSTDIR\bin\me3.exe" profile create -g ds3 --package darksouls3-mods darksouls3-default'
+
     CreateDirectory "$LOCALAPPDATA\garyttierney\me3\config\profiles\eldenring-mods"
     nsExec::Exec '"$INSTDIR\bin\me3.exe" profile create -g er --package eldenring-mods eldenring-default'
 
@@ -201,6 +204,10 @@ Section "Main Application" SEC01
     nsExec::Exec '"$INSTDIR\bin\me3.exe" profile create -g nr --package nightreign-mods nightreign-default'
 
     CreateDirectory "$SMPROGRAMS\me3"
+    CreateShortCut "$SMPROGRAMS\me3\DARK SOULS III (me3).lnk" "$INSTDIR\bin\me3.exe" \
+      "launch -p darksouls3-default" "$INSTDIR\assets\me3.ico" "" "" \
+      "" "Launch DARK SOULS III with the darksouls3-default mod profile"
+
     CreateShortCut "$SMPROGRAMS\me3\ELDEN RING (me3).lnk" "$INSTDIR\bin\me3.exe" \
       "launch -p eldenring-default" "$INSTDIR\assets\me3.ico" "" "" \
       "" "Launch ELDEN RING with the eldenring-default mod profile"
@@ -240,6 +247,7 @@ Section "Uninstall"
     Delete "$INSTDIR\CHANGELOG.md"
     Delete "$INSTDIR\README.txt"
     Delete "$INSTDIR\assets\me3.ico"
+    Delete "$SMPROGRAMS\me3\DARK SOULS III (me3).lnk"
     Delete "$SMPROGRAMS\me3\ELDEN RING (me3).lnk"
     Delete "$SMPROGRAMS\me3\NIGHTREIGN (me3).lnk"
     Delete "$SMPROGRAMS\me3\Documentation.URL"

--- a/installer.nsi
+++ b/installer.nsi
@@ -193,8 +193,12 @@ Section "Main Application" SEC01
 
     WriteRegStr HKCU "Software\${PRODUCT}" "Install_Dir" $INSTDIR
     nsExec::Exec '"$INSTDIR\bin\me3.exe" add-to-path'
-    nsExec::Exec '"$INSTDIR\bin\me3.exe" profile create -g nr nightreign-default --package nightreign-mods'
-    nsExec::Exec '"$INSTDIR\bin\me3.exe" profile create -g er eldenring-default --package eldenring-mods'
+
+    CreateDirectory "$LOCALAPPDATA\garyttierney\me3\config\profiles\eldenring-mods"
+    nsExec::Exec '"$INSTDIR\bin\me3.exe" profile create -g er --package eldenring-mods eldenring-default'
+
+    CreateDirectory "$LOCALAPPDATA\garyttierney\me3\config\profiles\nightreign-mods"
+    nsExec::Exec '"$INSTDIR\bin\me3.exe" profile create -g nr --package nightreign-mods nightreign-default'
 
     CreateDirectory "$SMPROGRAMS\me3"
     CreateShortCut "$SMPROGRAMS\me3\ELDEN RING (me3).lnk" "$INSTDIR\bin\me3.exe" \


### PR DESCRIPTION
Uniformly handle profile names and paths (a profile mentioned by name as `MyMod2.1` should not be attempted to be loaded as `MyMod2.me3`) and move the package directory creation directives necessary for the installation process into the installer itself. Also add Dark Souls 3 to the installer.

Closes #346