### PR TITLE
fix(linux): Fix path remapping for SLR

### DIFF
--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -45,7 +45,7 @@ fn remap_slr_path(path: impl AsRef<Path>) -> PathBuf {
         .iter()
         .any(|prefix| path.starts_with(prefix))
     {
-        Path::new("/run/host").join(path)
+        Path::new("/run/host").join(path.strip_prefix("/").unwrap())
     } else {
         path.to_path_buf()
     }


### PR DESCRIPTION
Closes #416

Tested with no me3 config in any of the searched paths, and with win bins installed to:

```
/usr/lib64/me3/x86_64-windows/me3_mod_host.dll
/usr/lib64/me3/x86_64-windows/me3-launcher.exe
```

Before:

```console
$ /usr/bin/me3 launch -g er # fails to launch
... ME3_LAUNCHER_HOST_DLL="\"/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
... proton" "waitforexitandrun" "/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
```

After:

```console
$ cargo run --release --target x86_64-unknown-linux-gnu --bin me3 launch -g er # ok
... ME3_LAUNCHER_HOST_DLL="\"/run/host/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
... proton" "waitforexitandrun" "/run/host/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
```
