### PR TITLE
chore: Release v0.9.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,11 +22,11 @@ body:
       description: What version of our software are you running?
       options:
         - prerelease
+        - v0.9.1
         - v0.9.0
         - v0.8.1
         - v0.8.0
         - v0.7.0
-        - v0.6.1
       default: 1
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 <!-- markdown-link-check-disable -->
 <!-- ignore lint rules that are often triggered by content generated from commits / git-cliff -->
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
+## me3 - [v0.9.1](https://github.com/garyttierney/me3/releases/v0.9.1) - 2025-10-02
+
+### 🐛 Bug Fixes
+
+- [103199a](https://github.com/garyttierney/me3/commit/103199ac986363aa7dc464a515afe186a06aae5d)  *(linux)* Fix path remapping for SLR in [#552](https://github.com/garyttierney/me3/pull/552)
+
+
+  > Closes #416
+  > 
+  > Tested with no me3 config in any of the searched paths, and with win
+  > bins installed to:
+  > 
+  > ```
+  > /usr/lib64/me3/x86_64-windows/me3_mod_host.dll
+  > /usr/lib64/me3/x86_64-windows/me3-launcher.exe
+  > ```
+  > Before:```console
+  > $ /usr/bin/me3 launch -g er # fails to launch
+  > ... ME3_LAUNCHER_HOST_DLL="\"/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
+  > ... proton" "waitforexitandrun" "/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
+  > ```
+  > After:```console
+  > $ cargo run --release --target x86_64-unknown-linux-gnu --bin me3 launch -g er # ok
+  > ... ME3_LAUNCHER_HOST_DLL="\"/run/host/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
+  > ... proton" "waitforexitandrun" "/run/host/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
+  > ```
 ## me3 - [v0.9.0](https://github.com/garyttierney/me3/releases/v0.9.0) - 2025-09-24
 
 ### 🚀 Features
@@ -2579,6 +2605,7 @@ All notable changes to this project will be documented in this file.
 - [c4e6ef5](https://github.com/garyttierney/me3/commit/c4e6ef502776db75d89dbfef6c585b658a28caf4) Initial commit
 
 
+[0.9.1]: https://github.com/garyttierney/me3/compare/v0.9.0..v0.9.1
 [0.9.0]: https://github.com/garyttierney/me3/compare/v0.8.1..v0.9.0
 [0.8.1]: https://github.com/garyttierney/me3/compare/v0.7.0..v0.8.1
 [0.7.0]: https://github.com/garyttierney/me3/compare/v0.6.1..v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "me3-binary-analysis"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "pelite",
  "rayon",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "assert_fs",
  "chrono",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "me3-env"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "me3-mod-protocol",
  "serde",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crash-context",
  "dll-syringe",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bincode",
  "eyre",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "closure-ffi",
  "color-eyre",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "from-singleton",
  "me3-binary-analysis",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "me3-binary-analysis",
  "me3-env",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "expect-test",
  "indexmap",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "color-eyre",
  "eyre",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.9.0"
+version = "0.9.1"
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/binary-analysis/Cargo.toml
+++ b/crates/binary-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-binary-analysis"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-env"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher-attach-protocol/Cargo.toml
+++ b/crates/launcher-attach-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher-attach-protocol"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-assets"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-types/Cargo.toml
+++ b/crates/mod-host-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-types"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-protocol"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3_telemetry"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039  # local is non-POSIX
 set -u
 
-INSTALLER_VERSION=v0.9.0
+INSTALLER_VERSION=v0.9.1
 
 need_cmd() {
     if ! check_cmd "$1"; then


### PR DESCRIPTION

## [unreleased]

### 🐛 Bug Fixes

- [103199a](https://github.com/garyttierney/me3/commit/103199ac986363aa7dc464a515afe186a06aae5d)  *(linux)* Fix path remapping for SLR in [#552](https://github.com/garyttierney/me3/pull/552)


  > Closes #416
  > 
  > Tested with no me3 config in any of the searched paths, and with win
  > bins installed to:
  > 
  > ```
  > /usr/lib64/me3/x86_64-windows/me3_mod_host.dll
  > /usr/lib64/me3/x86_64-windows/me3-launcher.exe
  > ```
  > Before:```console
  > $ /usr/bin/me3 launch -g er # fails to launch
  > ... ME3_LAUNCHER_HOST_DLL="\"/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
  > ... proton" "waitforexitandrun" "/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
  > ```
  > After:```console
  > $ cargo run --release --target x86_64-unknown-linux-gnu --bin me3 launch -g er # ok
  > ... ME3_LAUNCHER_HOST_DLL="\"/run/host/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
  > ... proton" "waitforexitandrun" "/run/host/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
  > ```