### PR TITLE
chore: Release v0.10.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,11 +22,11 @@ body:
       description: What version of our software are you running?
       options:
         - prerelease
+        - v0.10.0
         - v0.9.0
         - v0.8.1
         - v0.8.0
         - v0.7.0
-        - v0.6.1
       default: 1
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,75 @@ All notable changes to this project will be documented in this file.
 <!-- markdown-link-check-disable -->
 <!-- ignore lint rules that are often triggered by content generated from commits / git-cliff -->
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
+## me3 - [v0.10.0](https://github.com/garyttierney/me3/releases/v0.10.0) - 2025-12-23
+
+### 🚀 Features
+
+- [67c8859](https://github.com/garyttierney/me3/commit/67c88590c8f973798df10adc0de30ad60629d189)  *(cli)* Set terminal title during launch in [#553](https://github.com/garyttierney/me3/pull/553)
+
+
+  > Closes #402
+  > 
+  > Set it relatively late to avoid flicker if the launch fails early e.g.
+  > invalid options or anything not found.
+
+- [e4508a9](https://github.com/garyttierney/me3/commit/e4508a9442eaf37bed27c704271b20c897e030dd)  *(host)* Compress bhd cache with deflate in [#615](https://github.com/garyttierney/me3/pull/615)
+
+
+
+- [092cb26](https://github.com/garyttierney/me3/commit/092cb26d9d97919834938ad3a2d9576f2bc4d6fb)  *(host)* Add mimalloc as a replacement memory allocator for ds3, sdt and er
+
+
+
+### 🐛 Bug Fixes
+
+- [e2bba6e](https://github.com/garyttierney/me3/commit/e2bba6ef9c9719d47e8a1c95cd75de29ce41d405)  *(linux)* Add appid for Proton 10 in [#584](https://github.com/garyttierney/me3/pull/584)
+
+
+
+- [103199a](https://github.com/garyttierney/me3/commit/103199ac986363aa7dc464a515afe186a06aae5d)  *(linux)* Fix path remapping for SLR in [#552](https://github.com/garyttierney/me3/pull/552)
+
+
+  > Closes #416
+  > 
+  > Tested with no me3 config in any of the searched paths, and with win
+  > bins installed to:
+  > 
+  > ```
+  > /usr/lib64/me3/x86_64-windows/me3_mod_host.dll
+  > /usr/lib64/me3/x86_64-windows/me3-launcher.exe
+  > ```
+  > Before:```console
+  > $ /usr/bin/me3 launch -g er # fails to launch
+  > ... ME3_LAUNCHER_HOST_DLL="\"/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
+  > ... proton" "waitforexitandrun" "/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
+  > ```
+  > After:```console
+  > $ cargo run --release --target x86_64-unknown-linux-gnu --bin me3 launch -g er # ok
+  > ... ME3_LAUNCHER_HOST_DLL="\"/run/host/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
+  > ... proton" "waitforexitandrun" "/run/host/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
+  > ```
+
+- [e682d0c](https://github.com/garyttierney/me3/commit/e682d0cb66945243add50c727642f1c878935e57) Make it possible to load natives premain in [#624](https://github.com/garyttierney/me3/pull/624)
+
+
+  > Fixes #621
+  > 
+  > ---------
+
+- [61129ad](https://github.com/garyttierney/me3/commit/61129add325ec260110fc43b051ee43e9791d639) Fallback to 'Verified on Deck' Proton runtimes in [#611](https://github.com/garyttierney/me3/pull/611)
+
+
+  > Steam Deck uses its own verification system to decide which Proton
+  > runtime a game should be ran with. This doesn't override the usual
+  > compat tool configuration, but is used if none exists.
+
+
+### 📚 Documentation
+
+- [2b509d1](https://github.com/garyttierney/me3/commit/2b509d13568fb209d65bbdde718e0e505d021971) Add Discord badge and link to README in [#558](https://github.com/garyttierney/me3/pull/558)
+
+
 ## me3 - [v0.9.0](https://github.com/garyttierney/me3/releases/v0.9.0) - 2025-09-24
 
 ### 🚀 Features
@@ -2579,6 +2648,7 @@ All notable changes to this project will be documented in this file.
 - [c4e6ef5](https://github.com/garyttierney/me3/commit/c4e6ef502776db75d89dbfef6c585b658a28caf4) Initial commit
 
 
+[0.10.0]: https://github.com/garyttierney/me3/compare/v0.9.0..v0.10.0
 [0.9.0]: https://github.com/garyttierney/me3/compare/v0.8.1..v0.9.0
 [0.8.1]: https://github.com/garyttierney/me3/compare/v0.7.0..v0.8.1
 [0.7.0]: https://github.com/garyttierney/me3/compare/v0.6.1..v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "me3-binary-analysis"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pelite",
  "rayon",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_fs",
  "chrono",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "me3-env"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "me3-mod-protocol",
  "serde",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "dll-syringe",
  "eyre",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "eyre",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64",
  "closure-ffi",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "from-singleton",
  "me3-binary-analysis",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "me3-binary-analysis",
  "me3-env",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "expect-test",
  "indexmap",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "color-eyre",
  "eyre",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.9.0"
+version = "0.10.0"
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/binary-analysis/Cargo.toml
+++ b/crates/binary-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-binary-analysis"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-env"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher-attach-protocol/Cargo.toml
+++ b/crates/launcher-attach-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher-attach-protocol"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-assets"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-types/Cargo.toml
+++ b/crates/mod-host-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-types"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-protocol"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3_telemetry"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039  # local is non-POSIX
 set -u
 
-INSTALLER_VERSION=v0.9.0
+INSTALLER_VERSION=v0.10.0
 
 need_cmd() {
     if ! check_cmd "$1"; then


### PR DESCRIPTION

## [unreleased]

### 🚀 Features

- [67c8859](https://github.com/garyttierney/me3/commit/67c88590c8f973798df10adc0de30ad60629d189)  *(cli)* Set terminal title during launch in [#553](https://github.com/garyttierney/me3/pull/553)


  > Closes #402
  > 
  > Set it relatively late to avoid flicker if the launch fails early e.g.
  > invalid options or anything not found.

- [e4508a9](https://github.com/garyttierney/me3/commit/e4508a9442eaf37bed27c704271b20c897e030dd)  *(host)* Compress bhd cache with deflate in [#615](https://github.com/garyttierney/me3/pull/615)



- [092cb26](https://github.com/garyttierney/me3/commit/092cb26d9d97919834938ad3a2d9576f2bc4d6fb)  *(host)* Add mimalloc as a replacement memory allocator for ds3, sdt and er



### 🐛 Bug Fixes

- [e2bba6e](https://github.com/garyttierney/me3/commit/e2bba6ef9c9719d47e8a1c95cd75de29ce41d405)  *(linux)* Add appid for Proton 10 in [#584](https://github.com/garyttierney/me3/pull/584)



- [103199a](https://github.com/garyttierney/me3/commit/103199ac986363aa7dc464a515afe186a06aae5d)  *(linux)* Fix path remapping for SLR in [#552](https://github.com/garyttierney/me3/pull/552)


  > Closes #416
  > 
  > Tested with no me3 config in any of the searched paths, and with win
  > bins installed to:
  > 
  > ```
  > /usr/lib64/me3/x86_64-windows/me3_mod_host.dll
  > /usr/lib64/me3/x86_64-windows/me3-launcher.exe
  > ```
  > Before:```console
  > $ /usr/bin/me3 launch -g er # fails to launch
  > ... ME3_LAUNCHER_HOST_DLL="\"/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
  > ... proton" "waitforexitandrun" "/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
  > ```
  > After:```console
  > $ cargo run --release --target x86_64-unknown-linux-gnu --bin me3 launch -g er # ok
  > ... ME3_LAUNCHER_HOST_DLL="\"/run/host/usr/lib64/me3/x86_64-windows/me3_mod_host.dll\""
  > ... proton" "waitforexitandrun" "/run/host/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
  > ```

- [e682d0c](https://github.com/garyttierney/me3/commit/e682d0cb66945243add50c727642f1c878935e57) Make it possible to load natives premain in [#624](https://github.com/garyttierney/me3/pull/624)


  > Fixes #621
  > 
  > ---------

- [61129ad](https://github.com/garyttierney/me3/commit/61129add325ec260110fc43b051ee43e9791d639) Fallback to 'Verified on Deck' Proton runtimes in [#611](https://github.com/garyttierney/me3/pull/611)


  > Steam Deck uses its own verification system to decide which Proton
  > runtime a game should be ran with. This doesn't override the usual
  > compat tool configuration, but is used if none exists.


### 📚 Documentation

- [2b509d1](https://github.com/garyttierney/me3/commit/2b509d13568fb209d65bbdde718e0e505d021971) Add Discord badge and link to README in [#558](https://github.com/garyttierney/me3/pull/558)