### PR TITLE
feat(cli): Profile creation with mod directory scanning

### DIFF
--- a/crates/mod-protocol/src/lib.rs
+++ b/crates/mod-protocol/src/lib.rs
@@ -115,6 +115,7 @@ impl ModProfile {
 pub struct ModProfileV1 {
     /// The games that this profile supports.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     supports: Vec<Supports>,
 
     /// Native modules (DLLs) that will be loaded.

--- a/crates/mod-protocol/src/lib.rs
+++ b/crates/mod-protocol/src/lib.rs
@@ -115,7 +115,6 @@ impl ModProfile {
 pub struct ModProfileV1 {
     /// The games that this profile supports.
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     supports: Vec<Supports>,
 
     /// Native modules (DLLs) that will be loaded.


### PR DESCRIPTION
Added options to automatically populate packages and natives from a specified mods directory during profile creation. Introduced `--from-mods-dir` and `mods_dir` arguments for improved user experience. Implemented a new function to scan the directory for DLLs and package directories, ensuring that existing native modules are not duplicated.

Also updated the `ModProfileV1` struct to skip serializing empty supports vector.

Example:
```bash
me3 profile create my-profile --game nr "C:\path\to\mods"
```

This PR replaces  #560  which was closed due to branch issues.