### PR TITLE
fix: Fallback to 'Verified on Deck' Proton runtimes

### DIFF
--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -24,7 +24,7 @@ use me3_launcher_attach_protocol::AttachConfig;
 use me3_mod_protocol::{native::Native, package::Package};
 use normpath::PathExt;
 use serde::{Deserialize, Serialize};
-use steamlocate::{CompatTool, Library, SteamDir};
+use steamlocate::{Library, SteamDir};
 use tempfile::NamedTempFile;
 use tracing::{error, info};
 
@@ -185,7 +185,7 @@ impl Launcher for DirectLauncher {
 
 #[derive(Debug)]
 pub struct CompatToolLauncher {
-    tool: CompatTool,
+    tool: proton::CompatTool,
     steam: SteamDir,
     library: Library,
     app_id: u32,
@@ -200,17 +200,13 @@ impl Launcher for CompatToolLauncher {
             .find_app(sniper_id)?
             .ok_or_eyre("unable to find Steam Linux Runtime")?;
 
-        let compat_tools = CompatTools::new(&self.steam);
-        let compat_tool = compat_tools
-            .find(self.tool.name.expect("compat tools must be named"))
-            .ok_or_eyre("unable to find compatibility tool installation")?;
         let sniper_path = sniper_library.resolve_app_dir(&sniper_app);
         let mut command = Command::new(sniper_path.join("run"));
 
         command.args([
             "--batch",
             "--",
-            &*compat_tool.install_path.join("proton").to_string_lossy(),
+            &*self.tool.install_path.join("proton").to_string_lossy(),
             "waitforexitandrun",
             &*launcher.to_string_lossy(),
         ]);
@@ -433,18 +429,27 @@ pub fn launch(db: DbContext, config: Config, args: LaunchArgs) -> color_eyre::Re
             "Steam was used to locate the WINE configuration and no game installation was found",
         )?;
 
-        let compat_tools = steam_dir.compat_tool_mapping()?;
-        let app_compat_tool = compat_tools
-            .get(&app_id)
-            .or_else(|| compat_tools.get(&0))
-            .ok_or_eyre("unable to find compat tool for game")?;
+        let compat_tool_mapping = steam_dir.compat_tool_mapping()?;
+        let compat_tools = CompatTools::new(&steam_dir);
 
-        info!(?app_compat_tool, "found compat tool for appid");
+        let app_compat_tool = compat_tool_mapping
+            .get(&app_id)
+            .or_else(|| compat_tool_mapping.get(&0));
+
+        let compat_tool_name = app_compat_tool
+            .and_then(|tool| tool.name.clone())
+            .or_else(|| game.0.verified_on_deck_runtime().map(|rt| rt.to_string()))
+            .ok_or_eyre("unable to determine Proton runtime to run game with")?;
+
+        let compat_tool = compat_tools.find(&compat_tool_name).ok_or_eyre(format!(
+            "unable to find installation of Proton runtime {compat_tool_name}"
+        ))?;
+
         let launcher = CompatToolLauncher {
             app_id,
             library: steam_library,
             steam: steam_dir,
-            tool: app_compat_tool.clone(),
+            tool: compat_tool,
         };
 
         launcher.into_command(launcher_path)

--- a/crates/cli/src/commands/launch/proton.rs
+++ b/crates/cli/src/commands/launch/proton.rs
@@ -64,6 +64,9 @@ impl<'a> CompatTools<'a> {
         let tool_appid = match name {
             "proton_experimental" => 1493710,
             "proton_hotfix" => 2180100,
+            "proton_6" => 1580130,
+            "proton_7" => 1887720,
+            "proton_8" => 2348590,
             "proton_9" => 2805730,
             "proton_10" => 3658110,
             name => {
@@ -88,6 +91,7 @@ impl<'a> CompatTools<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct CompatTool {
     pub name: String,
     pub display_name: String,

--- a/crates/mod-protocol/src/game.rs
+++ b/crates/mod-protocol/src/game.rs
@@ -22,6 +22,20 @@ pub enum Game {
 }
 
 impl Game {
+    /// The AppID of the Steam compatibility tool that was used to verify this game on Steam Deck.
+    pub const fn verified_on_deck_runtime(self) -> Option<&'static str> {
+        use Game::*;
+        // TODO: we need a better way to deal with this.
+        const PROTON_STABLE: &str = "proton_10";
+        match self {
+            DarkSouls3 => Some("proton_8"),
+            Sekiro => Some(PROTON_STABLE),
+            EldenRing => Some("proton_8"),
+            ArmoredCore6 => Some("proton_8"),
+            Nightreign => Some("proton_9"),
+        }
+    }
+
     /// The primary name of a game as a lowercase string.
     pub const fn name(self) -> &'static str {
         use Game::*;


### PR DESCRIPTION
Steam Deck uses its own verification system to decide which Proton runtime a game should be ran with. This doesn't override the usual compat tool configuration, but is used if none exists.