### PR TITLE
feat(host): Compress bhd cache with deflate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "me3-mod-host-types",
  "me3-mod-protocol",
  "me3_telemetry",
+ "miniz_oxide",
  "pelite",
  "pkcs1",
  "rayon",

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -57,6 +57,7 @@ windows = { workspace = true, features = [
 xxhash-rust = { version = "0.8", features = ["std", "xxh3"] }
 pkcs1 = { version = "0.7.5", features = ["std"] }
 base64 = "0.22.1"
+miniz_oxide = { version = "0.8.9", features = ["std"] }
 
 [build-dependencies]
 winresource = "0.1"


### PR DESCRIPTION
Decrypted BHD headers in the me3 cache directory are now compressed to reduce their size on disk by a factor of 3 and reduce IO overhead when starting the game. Previously cached files are not compatible and will not be used, feel free to clear all contents of the `me3/cache` directory.