### PR TITLE
fix: fix load_early with multiple natives

### DIFF
--- a/crates/cli/src/db/profile.rs
+++ b/crates/cli/src/db/profile.rs
@@ -157,7 +157,7 @@ impl Profile {
             }
         }
 
-        ordered_natives.sort_by_key(|native| !native.load_early);
+        ordered_natives.sort_by_key(|native| native.load_early);
         let early_natives =
             ordered_natives.split_off(ordered_natives.partition_point(|native| !native.load_early));
 

--- a/crates/mod-protocol/test-data/basic_config.me3.toml.expected
+++ b/crates/mod-protocol/test-data/basic_config.me3.toml.expected
@@ -12,6 +12,7 @@ V1(
                 load_after: [],
                 initializer: None,
                 finalizer: None,
+                load_early: false,
             },
         ],
         packages: [


### PR DESCRIPTION
fix: https://github.com/garyttierney/me3/issues/633
Fix load_early ordering so early natives are separated correctly when multiple natives are present.