### PR TITLE
chore: Release v0.11.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,11 +22,11 @@ body:
       description: What version of our software are you running?
       options:
         - prerelease
+        - v0.11.0
         - v0.10.1
         - v0.10.0
         - v0.9.0
         - v0.8.1
-        - v0.8.0
       default: 1
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 <!-- markdown-link-check-disable -->
 <!-- ignore lint rules that are often triggered by content generated from commits / git-cliff -->
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
-## me3 - [v0.10.1](https://github.com/garyttierney/me3/releases/v0.10.1) - 2025-12-24
+## me3 - [v0.11.0](https://github.com/garyttierney/me3/releases/v0.11.0) - 2026-02-28
 
 ### 🚀 Features
 
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
   > Set it relatively late to avoid flicker if the launch fails early e.g.
   > invalid options or anything not found.
 
+- [357ea39](https://github.com/garyttierney/me3/commit/357ea399ea1d6967a9a06d84ee21bd04f9330c05)  *(host)* Log game version on attach in [#639](https://github.com/garyttierney/me3/pull/639)
+
+
+
 - [e4508a9](https://github.com/garyttierney/me3/commit/e4508a9442eaf37bed27c704271b20c897e030dd)  *(host)* Compress bhd cache with deflate in [#615](https://github.com/garyttierney/me3/pull/615)
 
 
@@ -24,7 +28,86 @@ All notable changes to this project will be documented in this file.
 
 
 
+- [0b5092f](https://github.com/garyttierney/me3/commit/0b5092fbee7b1ad0d33ef4fc11a2981bd7e027a9)  *(installer)* Improve upgrade logic and clean uninstallation in [#645](https://github.com/garyttierney/me3/pull/645)
+
+
+  > fix #644
+  > 
+  > ---------
+
+- [8790a68](https://github.com/garyttierney/me3/commit/8790a684ba6930d14b3b8c39d80d0ec972a8f94f) Offload file logging to the launcher
+
+
+
+- [1d43d39](https://github.com/garyttierney/me3/commit/1d43d397a324873570080e3fa8fb082b2b5ef1a4) Use a named pipe for logging on Linux
+
+
+
+- [053780d](https://github.com/garyttierney/me3/commit/053780d063eed33d2e92afb9e8f9357213bcade4) Implement shared memory IPC
+
+
+
 ### 🐛 Bug Fixes
+
+- [ede89b5](https://github.com/garyttierney/me3/commit/ede89b5c065cf440e646cfe5bd9c8c5d1efb509b)  *(cli)* Avoid me3 update crash by using explicit native TLS agent in [#643](https://github.com/garyttierney/me3/pull/643)
+
+
+  > fix #642
+  > Upstream:https://github.com/algesten/ureq/blob/main/src/tls/mod.rs#L29-L42
+  > https://github.com/algesten/ureq/blob/main/src/lib.rs#L599-L616
+  > 
+  > ---------
+
+- [096bfc7](https://github.com/garyttierney/me3/commit/096bfc73444629d78cb018ea576e8aff3764e0fa)  *(linux)* Resolve Steam metadata when custom exe is used in [#719](https://github.com/garyttierney/me3/pull/719)
+
+
+  > Recently we split up the launch code and introduced a check for Linux
+  > launches to verify that the game was being run under Steam, while before
+  > it would unconditionally run under Steam even with a custom exe.
+
+  > This check is unfortunately a breaking change for users who were already
+  > passing `--exe` on Linux, so we need to accomodate that situation.
+
+
+- [58fbf37](https://github.com/garyttierney/me3/commit/58fbf3742f20d5cd3cbc081b67037ff748317bbe)  *(linux)* Append null terminator to wine DOS path conversion in [#720](https://github.com/garyttierney/me3/pull/720)
+
+
+  > Custom sounds and filesystem overrides were not loading on Linux when
+  > running the release build, even though they worked in the debug build.
+
+  > In the code that converts Linux paths to Wine DOS paths
+  > (`normalize_dos_path)`, the string being passed to Wine (`os_path`) was
+  > missing a null-terminator (`0`).
+  >   * In a debug build, the memory allocator accidentally had a zero byte at
+  > the end, so it worked.
+  >   * In a release build, the memory was not zeroed out, causing the
+  > function to read garbage data and fail to resolve the path.
+
+  > Appended a null byte (`0`) to the end of the `os_path` array to
+  > guarantee it is properly null-terminated before sending it to the Wine
+  > function.
+
+
+- [b1153ac](https://github.com/garyttierney/me3/commit/b1153ac9c1c4dcc388cfd79f530d9d9539c25053)  *(linux)* Convert Unix paths to DOS for WINE in [#700](https://github.com/garyttierney/me3/pull/700)
+
+
+  > Some APIs used by the game expect to work with Windows paths, and
+  > currently we passthrough the Unix path directly which can cause path
+  > parsing errors and missing game functionality. wwise is known to have
+  > problems with those paths, and this workaround should deal with that
+  > until we can investigate hooking closer to the fs/io code in wwise.
+
+  > Fixes #683
+  > 
+  > ---------
+
+- [51206fc](https://github.com/garyttierney/me3/commit/51206fc8f5777c4f0913b75900784f7f0817236c)  *(linux)* Mount any needed filesystems under SLR in [#661](https://github.com/garyttierney/me3/pull/661)
+
+
+
+- [f51911a](https://github.com/garyttierney/me3/commit/f51911adaeef0eba304cb2ad9e9c8f736f096c32)  *(linux)* Ignore empty Steam directories
+
+
 
 - [e2bba6e](https://github.com/garyttierney/me3/commit/e2bba6ef9c9719d47e8a1c95cd75de29ce41d405)  *(linux)* Add appid for Proton 10 in [#584](https://github.com/garyttierney/me3/pull/584)
 
@@ -53,6 +136,19 @@ All notable changes to this project will be documented in this file.
   > ... proton" "waitforexitandrun" "/run/host/usr/lib64/me3/x86_64-windows/me3-launcher.exe"
   > ```
 
+- [302663d](https://github.com/garyttierney/me3/commit/302663d15be79808393c25bdeef025ed08d502bf) Disable Steam input configuration check in [#728](https://github.com/garyttierney/me3/pull/728)
+
+
+  > This isn't working quite correctly. Certain users no longer see double
+  > inputs, but a larger number of users see no controller input at all.
+  > Needs more investigation to determine how this is supposed to be applied
+  > properly.
+
+
+- [a9a0c47](https://github.com/garyttierney/me3/commit/a9a0c47f42d2b2bdcdcc7f1053bc6dd5f1d7755c) Configure SDL to use Steam Input unless it's disabled
+
+
+
 - [dd3918d](https://github.com/garyttierney/me3/commit/dd3918d555285459a0ec84dae68631f5925ed488) Fix load_early with multiple natives in [#634](https://github.com/garyttierney/me3/pull/634)
 
 
@@ -77,6 +173,10 @@ All notable changes to this project will be documented in this file.
 
 
 ### 📚 Documentation
+
+- [62e7d9f](https://github.com/garyttierney/me3/commit/62e7d9f1585db4bb05705238ae20d58f2cbd19df) Explain new "load_early" profile setting in [#652](https://github.com/garyttierney/me3/pull/652)
+
+
 
 - [2b509d1](https://github.com/garyttierney/me3/commit/2b509d13568fb209d65bbdde718e0e505d021971) Add Discord badge and link to README in [#558](https://github.com/garyttierney/me3/pull/558)
 
@@ -2656,7 +2756,7 @@ All notable changes to this project will be documented in this file.
 - [c4e6ef5](https://github.com/garyttierney/me3/commit/c4e6ef502776db75d89dbfef6c585b658a28caf4) Initial commit
 
 
-[0.10.1]: https://github.com/garyttierney/me3/compare/v0.9.0..v0.10.1
+[0.11.0]: https://github.com/garyttierney/me3/compare/v0.9.0..v0.11.0
 [0.9.0]: https://github.com/garyttierney/me3/compare/v0.8.1..v0.9.0
 [0.8.1]: https://github.com/garyttierney/me3/compare/v0.7.0..v0.8.1
 [0.7.0]: https://github.com/garyttierney/me3/compare/v0.6.1..v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "me3-binary-analysis"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "pelite",
  "rayon",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "assert_fs",
  "base64",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "me3-env"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "me3-mod-protocol",
  "serde",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "me3-ipc"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "me3-env",
  "me3-launcher-attach-protocol",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "eyre",
  "me3-env",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "eyre",
  "me3-mod-protocol",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "base64",
  "closure-ffi",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "from-singleton",
  "libc",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-types"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "me3-binary-analysis",
  "me3-env",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "expect-test",
  "indexmap",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "color-eyre",
  "eyre",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.10.1"
+version = "0.11.0"
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/binary-analysis/Cargo.toml
+++ b/crates/binary-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-binary-analysis"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-cli"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-env"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/ipc/Cargo.toml
+++ b/crates/ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-ipc"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher-attach-protocol/Cargo.toml
+++ b/crates/launcher-attach-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher-attach-protocol"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-assets"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-types/Cargo.toml
+++ b/crates/mod-host-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-types"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-protocol"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3_telemetry"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039  # local is non-POSIX
 set -u
 
-INSTALLER_VERSION=v0.10.1
+INSTALLER_VERSION=v0.11.0
 
 need_cmd() {
     if ! check_cmd "$1"; then


### PR DESCRIPTION

## [unreleased]

### 🚀 Features

- [357ea39](https://github.com/garyttierney/me3/commit/357ea399ea1d6967a9a06d84ee21bd04f9330c05)  *(host)* Log game version on attach in [#639](https://github.com/garyttierney/me3/pull/639)



- [0b5092f](https://github.com/garyttierney/me3/commit/0b5092fbee7b1ad0d33ef4fc11a2981bd7e027a9)  *(installer)* Improve upgrade logic and clean uninstallation in [#645](https://github.com/garyttierney/me3/pull/645)


  > fix #644
  > 
  > ---------

- [8790a68](https://github.com/garyttierney/me3/commit/8790a684ba6930d14b3b8c39d80d0ec972a8f94f) Offload file logging to the launcher



- [1d43d39](https://github.com/garyttierney/me3/commit/1d43d397a324873570080e3fa8fb082b2b5ef1a4) Use a named pipe for logging on Linux



- [053780d](https://github.com/garyttierney/me3/commit/053780d063eed33d2e92afb9e8f9357213bcade4) Implement shared memory IPC



### 🐛 Bug Fixes

- [ede89b5](https://github.com/garyttierney/me3/commit/ede89b5c065cf440e646cfe5bd9c8c5d1efb509b)  *(cli)* Avoid me3 update crash by using explicit native TLS agent in [#643](https://github.com/garyttierney/me3/pull/643)


  > fix #642
  > Upstream:https://github.com/algesten/ureq/blob/main/src/tls/mod.rs#L29-L42
  > https://github.com/algesten/ureq/blob/main/src/lib.rs#L599-L616
  > 
  > ---------

- [096bfc7](https://github.com/garyttierney/me3/commit/096bfc73444629d78cb018ea576e8aff3764e0fa)  *(linux)* Resolve Steam metadata when custom exe is used in [#719](https://github.com/garyttierney/me3/pull/719)


  > Recently we split up the launch code and introduced a check for Linux
  > launches to verify that the game was being run under Steam, while before
  > it would unconditionally run under Steam even with a custom exe.

  > This check is unfortunately a breaking change for users who were already
  > passing `--exe` on Linux, so we need to accomodate that situation.


- [58fbf37](https://github.com/garyttierney/me3/commit/58fbf3742f20d5cd3cbc081b67037ff748317bbe)  *(linux)* Append null terminator to wine DOS path conversion in [#720](https://github.com/garyttierney/me3/pull/720)


  > Custom sounds and filesystem overrides were not loading on Linux when
  > running the release build, even though they worked in the debug build.

  > In the code that converts Linux paths to Wine DOS paths
  > (`normalize_dos_path)`, the string being passed to Wine (`os_path`) was
  > missing a null-terminator (`0`).
  >   * In a debug build, the memory allocator accidentally had a zero byte at
  > the end, so it worked.
  >   * In a release build, the memory was not zeroed out, causing the
  > function to read garbage data and fail to resolve the path.

  > Appended a null byte (`0`) to the end of the `os_path` array to
  > guarantee it is properly null-terminated before sending it to the Wine
  > function.


- [b1153ac](https://github.com/garyttierney/me3/commit/b1153ac9c1c4dcc388cfd79f530d9d9539c25053)  *(linux)* Convert Unix paths to DOS for WINE in [#700](https://github.com/garyttierney/me3/pull/700)


  > Some APIs used by the game expect to work with Windows paths, and
  > currently we passthrough the Unix path directly which can cause path
  > parsing errors and missing game functionality. wwise is known to have
  > problems with those paths, and this workaround should deal with that
  > until we can investigate hooking closer to the fs/io code in wwise.

  > Fixes #683
  > 
  > ---------

- [51206fc](https://github.com/garyttierney/me3/commit/51206fc8f5777c4f0913b75900784f7f0817236c)  *(linux)* Mount any needed filesystems under SLR in [#661](https://github.com/garyttierney/me3/pull/661)



- [f51911a](https://github.com/garyttierney/me3/commit/f51911adaeef0eba304cb2ad9e9c8f736f096c32)  *(linux)* Ignore empty Steam directories



- [302663d](https://github.com/garyttierney/me3/commit/302663d15be79808393c25bdeef025ed08d502bf) Disable Steam input configuration check in [#728](https://github.com/garyttierney/me3/pull/728)


  > This isn't working quite correctly. Certain users no longer see double
  > inputs, but a larger number of users see no controller input at all.
  > Needs more investigation to determine how this is supposed to be applied
  > properly.


- [a9a0c47](https://github.com/garyttierney/me3/commit/a9a0c47f42d2b2bdcdcc7f1053bc6dd5f1d7755c) Configure SDL to use Steam Input unless it's disabled



### 📚 Documentation

- [62e7d9f](https://github.com/garyttierney/me3/commit/62e7d9f1585db4bb05705238ae20d58f2cbd19df) Explain new "load_early" profile setting in [#652](https://github.com/garyttierney/me3/pull/652)