### PR TITLE
fix(cli): avoid me3 update crash by using explicit native TLS agent

### DIFF
--- a/crates/cli/src/commands/windows.rs
+++ b/crates/cli/src/commands/windows.rs
@@ -48,7 +48,12 @@ pub fn update() -> color_eyre::Result<()> {
     use ureq::tls::{RootCerts, TlsConfig, TlsProvider};
 
     let agent = ureq::Agent::config_builder()
-        .tls_config(TlsConfig::builder().provider(TlsProvider::NativeTls).root_certs(RootCerts::PlatformVerifier).build())
+        .tls_config(
+            TlsConfig::builder()
+                .provider(TlsProvider::NativeTls)
+                .root_certs(RootCerts::PlatformVerifier)
+                .build(),
+        )
         .build()
         .new_agent();
 
@@ -86,7 +91,10 @@ pub fn update() -> color_eyre::Result<()> {
 
         info!(installer_url, "Downloading installer");
 
-        let response = agent.get(&installer_url).header("User-Agent", "me3-cli").call()?;
+        let response = agent
+            .get(&installer_url)
+            .header("User-Agent", "me3-cli")
+            .call()?;
 
         let mut installer_file: tempfile::NamedTempFile = tempfile::Builder::new()
             .disable_cleanup(true)


### PR DESCRIPTION
fix #642


Upstream:
https://github.com/algesten/ureq/blob/main/src/tls/mod.rs#L29-L42 
https://github.com/algesten/ureq/blob/main/src/lib.rs#L599-L616