### PR TITLE
fix(cli): use normalize_virtually for pipe path on windows

### DIFF
--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -480,6 +480,10 @@ pub fn launch(
         host_config_path: attach_config_file.path().to_path_buf(),
     };
 
+    #[cfg(target_os = "windows")]
+    let monitor_pipe_path = monitor_pipe.path().normalize_virtually()?.into_path_buf();
+
+    #[cfg(not(target_os = "windows"))]
     let monitor_pipe_path = monitor_pipe.path().normalize()?.into_path_buf();
 
     let telemetry_vars = TelemetryVars {


### PR DESCRIPTION
Fixes reaching an unimplemented function in Wine when running the Windows binary of me3. I originally ran into this issue when trying to play the Windows version of [Dark Souls III Archipelago v4.0.0](https://github.com/fswap/from-software-archipelago-clients/releases/tag/ds3-v4.0.0) in my custom Wine prefix and it turns out it just needed a one line change to stop crashing on startup!

Here was the original log messages when it was crashing on startup.
```
 INFO launch: me3::commands::launch: monitor pipe created path="\\\\.\\pipe\\bxV-1I-6omPhnkynIMn2gw=="
 INFO launch: me3::commands::launch: created log file log_file_path="C:\\users\\steamuser\\AppData\\Local\\garyttierney\\me3\\data\\logs\\me3-config\\2026-04-15_02-27-41.log"
ERROR launch: me3::commands::launch: error=Invalid function. (os error 1)
```