### PR TITLE
fix(host): Don't expose fully qualified UTF-8 paths to the game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,11 +1802,13 @@ dependencies = [
  "rayon",
  "rdvec",
  "regex",
+ "slab",
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
  "undname",
  "windows 0.62.2",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3128,9 +3130,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slice-pool2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false }
 ureq = { version = "3", default-features = false, features = ["native-tls"] }
 windows = "0.62"
+xxhash-rust = { version = "0.8", features = ["std", "xxh3"] }
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -19,10 +19,12 @@ pelite = "0.10"
 rayon.workspace = true
 rdvec.workspace = true
 regex = "1"
+slab = "0.4.12"
 smallvec = { version = "1.15.1", features = ["const_generics", "const_new", "union"] }
 thiserror.workspace = true
 tracing.workspace = true
 undname = "2.1"
+xxhash-rust.workspace = true
 
 [dependencies.windows]
 features = ["Win32_Media", "Win32_System_Memory", "Win32_System_Kernel", "Win32_System_Threading"]

--- a/crates/mod-host-assets/src/mapping.rs
+++ b/crates/mod-host-assets/src/mapping.rs
@@ -147,14 +147,24 @@ impl VfsOverrideMapping {
         Ok(())
     }
 
-    pub fn vfs_override<S: AsRef<OsStr>>(&self, path_str: S) -> Option<VfsOverride<'_>> {
+    pub fn virtual_to_disk<S: AsRef<OsStr>>(&self, path_str: S) -> Option<&VfsOverride<'static>> {
         let path = Path::new(&path_str);
 
-        if let Some(savefile_override) = &self.savefile_override
-            && let Ok(key) = VfsKey::for_disk_path(path)
-            && let Some(savefile_override_path) = savefile_override.try_override(path, &key)
-        {
-            return Some(savefile_override_path.clone());
+        if let Some(savefile_override) = self.virtual_to_savefile(path) {
+            return Some(savefile_override);
+        }
+
+        let key = VfsKey::for_vfs_path(path);
+        let index = *self.vfs_map.get(&key)?;
+
+        self.overrides.get(index)
+    }
+
+    pub fn virtual_to_uid<S: AsRef<OsStr>>(&self, path_str: S) -> Option<VfsOverride<'_>> {
+        let path = Path::new(&path_str);
+
+        if let Some(savefile_override) = self.virtual_to_savefile(path) {
+            return Some(savefile_override.clone());
         }
 
         let key = VfsKey::for_vfs_path(path);
@@ -172,8 +182,11 @@ impl VfsOverrideMapping {
         ))
     }
 
-    pub fn disk_override<S: AsRef<OsStr>>(&self, path_str: S) -> Option<&VfsOverride<'static>> {
-        if let Some(from_uid) = self.disk_uid_override(path_str.as_ref()) {
+    pub fn disk_or_uid_to_disk<S: AsRef<OsStr>>(
+        &self,
+        path_str: S,
+    ) -> Option<&VfsOverride<'static>> {
+        if let Some(from_uid) = self.uid_to_disk(path_str.as_ref()) {
             return Some(from_uid);
         }
 
@@ -183,8 +196,14 @@ impl VfsOverrideMapping {
         self.overrides.get(*index)
     }
 
-    fn disk_uid_override<S: AsRef<OsStr>>(&self, uid_str: S) -> Option<&VfsOverride<'static>> {
-        let VfsUid { generation, index } = VfsUid::try_parse(uid_str.as_ref())?;
+    fn virtual_to_savefile(&self, path: &Path) -> Option<&VfsOverride<'static>> {
+        let savefile_override = self.savefile_override.as_ref()?;
+        let key = VfsKey::for_disk_path(path).ok()?;
+        savefile_override.try_override(path, &key)
+    }
+
+    fn uid_to_disk(&self, uid_str: &OsStr) -> Option<&VfsOverride<'static>> {
+        let VfsUid { generation, index } = VfsUid::try_parse(uid_str)?;
         let vfs_override = self.overrides.get(index)?;
 
         (generation == vfs_override.generation).then_some(vfs_override)
@@ -270,7 +289,7 @@ impl VfsUid {
         Self { generation, index }
     }
 
-    pub fn to_uid_string(&self) -> String {
+    pub fn to_uid_string(self) -> String {
         self.with_fmt_args(|fmt| format!("{fmt}"))
     }
 
@@ -410,19 +429,19 @@ mod test {
 
         assert!(
             asset_mapping
-                .vfs_override("data0:/regulation.bin")
+                .virtual_to_uid("data0:/regulation.bin")
                 .is_some(),
             "override for regulation.bin was not found"
         );
         assert!(
             asset_mapping
-                .vfs_override("data0:/event/common.emevd.dcx")
+                .virtual_to_uid("data0:/event/common.emevd.dcx")
                 .is_some(),
             "override for event/common.emevd.dcx not found"
         );
         assert!(
             asset_mapping
-                .vfs_override("data0:/common.emevd.dcx")
+                .virtual_to_uid("data0:/common.emevd.dcx")
                 .is_none(),
             "event/common.emevd.dcx was found incorrectly under the regulation root"
         );

--- a/crates/mod-host-assets/src/mapping.rs
+++ b/crates/mod-host-assets/src/mapping.rs
@@ -1,36 +1,43 @@
 use std::{
-    borrow::Borrow,
+    borrow::{Borrow, Cow},
     collections::HashMap,
     env,
-    ffi::OsStr,
+    ffi::{OsStr, OsString},
     fmt,
     fs::read_dir,
     io, iter,
-    os::windows::{ffi::OsStrExt as WinOsStrExt, fs::FileTypeExt},
+    os::windows::{
+        ffi::{OsStrExt, OsStringExt},
+        fs::FileTypeExt,
+    },
     path::{Path, PathBuf, StripPrefixError},
 };
 
 use me3_mod_protocol::package::{AssetOverrideSource, Package};
 use normpath::PathExt;
 use rayon::iter::{ParallelBridge, ParallelIterator};
+use slab::Slab;
 use smallvec::{smallvec_inline, SmallVec};
 use thiserror::Error;
-use windows::core::{PCSTR, PCWSTR};
+use windows::core::PCWSTR;
+use xxhash_rust::xxh3::Xxh3DefaultBuilder;
 
-use crate::platform::normalize_dos_path;
+use crate::{mapping::savefile::SavefileOverrideMapping, platform::normalize_dos_path};
 
 mod savefile;
 
 pub struct VfsOverrideMapping {
-    map: HashMap<VfsKey, VfsOverride>,
     current_dir: VfsKey,
-    savefile_override: Option<savefile::SavefileOverrideMapping>,
+    vfs_map: HashMap<VfsKey, usize, Xxh3DefaultBuilder>,
+    overrides: Slab<VfsOverride<'static>>,
+    savefile_override: Option<SavefileOverrideMapping>,
 }
 
-pub struct VfsOverride {
-    display: Box<str>,
-    path_c_str: Box<Path>,
+#[derive(Clone)]
+pub struct VfsOverride<'a> {
+    generation: Generation,
     wide_c_str: Box<[u16]>,
+    display: Cow<'a, str>,
 }
 
 #[derive(Debug, Error)]
@@ -55,8 +62,9 @@ impl VfsOverrideMapping {
             .map_err(VfsOverrideMappingError::ReadDir)?;
 
         Ok(Self {
-            map: HashMap::new(),
             current_dir,
+            vfs_map: HashMap::default(),
+            overrides: Slab::new(),
             savefile_override: None,
         })
     }
@@ -69,7 +77,7 @@ impl VfsOverrideMapping {
         fn scan_directories_inner(
             base_dir: &Path,
             root_key: &VfsKey,
-        ) -> SmallVec<[Result<(VfsKey, VfsOverride), io::Error>; 1]> {
+        ) -> SmallVec<[Result<(VfsKey, VfsOverride<'static>), io::Error>; 1]> {
             let entries = match read_dir(base_dir) {
                 Ok(entries) => entries,
                 Err(e) => return smallvec_inline![Err(e)],
@@ -85,8 +93,10 @@ impl VfsOverrideMapping {
                     Ok(_) => {
                         let path = dir_entry.path();
 
-                        let result = VfsKey::for_asset_path(&path, root_key)
-                            .map(|vfs_key| (vfs_key, VfsOverride::new(&path)));
+                        let result = VfsKey::for_asset_path(&path, root_key).map(|vfs_key| {
+                            let display = path.to_string_lossy().into_owned();
+                            (vfs_key, VfsOverride::new(path, Generation, display.into()))
+                        });
 
                         smallvec_inline![result]
                     }
@@ -104,11 +114,15 @@ impl VfsOverrideMapping {
                 .map_err(VfsOverrideMappingError::ReadDir)?;
 
             let scanned_directories = scan_directories_inner(&normalized_path, &root_key);
-            self.map.reserve(scanned_directories.len());
+
+            self.overrides.reserve(scanned_directories.len());
+            self.vfs_map.reserve(scanned_directories.len());
 
             for result in scanned_directories {
                 let (vfs_key, vfs_override) = result.map_err(VfsOverrideMappingError::ReadDir)?;
-                self.map.insert(vfs_key, vfs_override);
+
+                let index = self.overrides.insert(vfs_override);
+                self.vfs_map.insert(vfs_key, index);
             }
         }
 
@@ -128,122 +142,160 @@ impl VfsOverrideMapping {
         P: AsRef<Path>,
         F: Fn(&Path) -> PathBuf + Send + Sync + 'static,
     {
-        let savefile_override = savefile::SavefileOverrideMapping::new(savefile_dir, f)?;
+        let savefile_override = SavefileOverrideMapping::new(savefile_dir, f)?;
         self.savefile_override = Some(savefile_override);
         Ok(())
     }
 
-    pub fn vfs_override<S: AsRef<OsStr>>(&self, path_str: S) -> Option<&VfsOverride> {
+    pub fn vfs_override<S: AsRef<OsStr>>(&self, path_str: S) -> Option<VfsOverride<'_>> {
         let path = Path::new(&path_str);
 
         if let Some(savefile_override) = &self.savefile_override
             && let Ok(key) = VfsKey::for_disk_path(path)
             && let Some(savefile_override_path) = savefile_override.try_override(path, &key)
         {
-            return Some(savefile_override_path);
+            return Some(savefile_override_path.clone());
         }
 
         let key = VfsKey::for_vfs_path(path);
-        self.map.get(&key)
+        let index = *self.vfs_map.get(&key)?;
+
+        let vfs_override = self.overrides.get(index)?;
+        let vfs_uid = VfsUid::new(index, vfs_override.generation);
+
+        let uid_path = vfs_uid.to_uid_string();
+
+        Some(VfsOverride::new(
+            uid_path,
+            vfs_override.generation,
+            Cow::Borrowed(&vfs_override.display),
+        ))
     }
 
-    pub fn disk_override<S: AsRef<OsStr>>(&self, path_str: S) -> Option<&VfsOverride> {
+    pub fn disk_override<S: AsRef<OsStr>>(&self, path_str: S) -> Option<&VfsOverride<'static>> {
+        if let Some(from_uid) = self.disk_uid_override(path_str.as_ref()) {
+            return Some(from_uid);
+        }
+
         let key = VfsKey::for_asset_path(Path::new(&path_str), &self.current_dir).ok()?;
-        self.map.get(&key)
+        let index = self.vfs_map.get(&key)?;
+
+        self.overrides.get(*index)
+    }
+
+    fn disk_uid_override<S: AsRef<OsStr>>(&self, uid_str: S) -> Option<&VfsOverride<'static>> {
+        let VfsUid { generation, index } = VfsUid::try_parse(uid_str.as_ref())?;
+        let vfs_override = self.overrides.get(index)?;
+
+        (generation == vfs_override.generation).then_some(vfs_override)
     }
 }
 
-impl VfsOverride {
-    pub fn new<P: AsRef<Path>>(path: P) -> Self {
-        let display = path.as_ref().display().to_string().into_boxed_str();
-
-        let (wide_c_str, path_c_str) = {
-            let mut os_str = path.as_ref().as_os_str().to_os_string();
-            os_str.push("\0");
-
-            (
-                Vec::into_boxed_slice(os_str.encode_wide().collect()),
-                PathBuf::into_boxed_path(os_str.into()),
-            )
-        };
-
+impl<'a> VfsOverride<'a> {
+    fn new<P: AsRef<OsStr>>(path: P, generation: Generation, display: Cow<'a, str>) -> Self {
         Self {
+            generation,
+            wide_c_str: path.as_ref().encode_wide().chain([0]).collect(),
             display,
-            path_c_str,
-            wide_c_str,
         }
     }
 
-    pub fn as_str_lossy(&self) -> &str {
-        &self.display
+    pub fn to_path_buf(&self) -> PathBuf {
+        PathBuf::from(OsString::from_wide(self.as_wide()))
     }
 
-    pub fn as_path(&self) -> &Path {
-        let bytes_with_nul = self.path_c_str.as_os_str().as_encoded_bytes();
-        let bytes_without_nul = &bytes_with_nul[..bytes_with_nul.len() - 1];
-
-        // SAFETY: Source OsStr bytes split before valid substring ("\0"),
-        // which is always inserted by `VfsOverride::new`
-        unsafe { Path::new(OsStr::from_encoded_bytes_unchecked(bytes_without_nul)) }
+    pub fn to_c_string(&self) -> Vec<u8> {
+        OsString::from_wide(self.as_wide_c_string()).into_encoded_bytes()
     }
 
     pub fn as_wide(&self) -> &[u16] {
         &self.wide_c_str[..self.wide_c_str.len() - 1]
     }
 
-    pub fn as_c_str(&self) -> *const u8 {
-        self.path_c_str.as_os_str().as_encoded_bytes().as_ptr()
-    }
-
-    pub fn as_wide_c_str(&self) -> *const u16 {
-        self.wide_c_str.as_ptr()
-    }
-
-    pub fn as_pcstr(&self) -> PCSTR {
-        PCSTR::from_raw(self.as_c_str())
+    pub fn as_wide_c_string(&self) -> &[u16] {
+        &self.wide_c_str
     }
 
     pub fn as_pcwstr(&self) -> PCWSTR {
-        PCWSTR::from_raw(self.as_wide_c_str())
+        PCWSTR(self.as_wide_c_string().as_ptr())
+    }
+
+    pub fn as_display_str(&self) -> &str {
+        &self.display
     }
 }
 
-impl fmt::Debug for VfsOverride {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("VfsOverride")
-            .field("display", &self.display)
-            .field("path", &self.as_path())
-            .finish()
-    }
-}
-
-impl fmt::Display for VfsOverride {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.display.fmt(f)
-    }
-}
-
-impl AsRef<Path> for VfsOverride {
-    fn as_ref(&self) -> &Path {
-        self.as_path()
-    }
-}
-
-impl AsRef<[u16]> for VfsOverride {
+impl AsRef<[u16]> for VfsOverride<'_> {
     fn as_ref(&self) -> &[u16] {
         self.as_wide()
     }
 }
 
-impl From<&VfsOverride> for PCSTR {
-    fn from(value: &VfsOverride) -> Self {
-        value.as_pcstr()
+impl From<&VfsOverride<'_>> for PCWSTR {
+    fn from(vfs_override: &VfsOverride<'_>) -> Self {
+        vfs_override.as_pcwstr()
     }
 }
 
-impl From<&VfsOverride> for PCWSTR {
-    fn from(value: &VfsOverride) -> Self {
-        value.as_pcwstr()
+impl fmt::Debug for VfsOverride<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VfsOverride")
+            .field("generation", &self.generation)
+            .field("path", &self.to_path_buf())
+            .field("display", &self.as_display_str())
+            .finish()
+    }
+}
+
+impl fmt::Display for VfsOverride<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_display_str())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct VfsUid {
+    generation: Generation,
+    index: usize,
+}
+
+// May become a `usize` in the future to implement asset reloading.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Generation;
+
+impl VfsUid {
+    const ROOT: &str = r"\\me3";
+
+    fn new(index: usize, generation: Generation) -> Self {
+        Self { generation, index }
+    }
+
+    pub fn to_uid_string(&self) -> String {
+        self.with_fmt_args(|fmt| format!("{fmt}"))
+    }
+
+    pub fn try_parse(str: &OsStr) -> Option<Self> {
+        let str = str.to_str()?;
+
+        let index_str = str.strip_prefix(Self::ROOT)?.strip_prefix("??")?;
+        let index = usize::from_str_radix(index_str, 16).ok()?;
+
+        Some(Self::new(index, Generation))
+    }
+
+    #[inline(always)]
+    fn with_fmt_args<T>(&self, f: impl FnOnce(fmt::Arguments<'_>) -> T) -> T {
+        let root = Self::ROOT;
+        let generation = "";
+        let index = self.index;
+
+        f(format_args!("{root}?{generation}?{index:x}"))
+    }
+}
+
+impl fmt::Display for VfsUid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.with_fmt_args(|fmt| f.write_fmt(fmt))
     }
 }
 

--- a/crates/mod-host-assets/src/mapping/savefile.rs
+++ b/crates/mod-host-assets/src/mapping/savefile.rs
@@ -28,7 +28,7 @@ impl SavefileOverrideMapping {
     }
 
     #[inline]
-    pub fn try_override(&self, path: &Path, key: &VfsKey) -> Option<&VfsOverride<'_>> {
+    pub fn try_override(&self, path: &Path, key: &VfsKey) -> Option<&VfsOverride<'static>> {
         if path.extension() != Some(OsStr::new("bak")) {
             self.try_override_inner(path, key).map(|(sl2, _)| sl2)
         } else {
@@ -42,7 +42,7 @@ impl SavefileOverrideMapping {
         &self,
         path: &Path,
         key: &VfsKey,
-    ) -> Option<&(VfsOverride<'_>, VfsOverride<'_>)> {
+    ) -> Option<&(VfsOverride<'static>, VfsOverride<'static>)> {
         if path.extension() != Some(OsStr::new("sl2")) || !key.0.starts_with(&self.savefile_dir) {
             return None;
         }

--- a/crates/mod-host-assets/src/mapping/savefile.rs
+++ b/crates/mod-host-assets/src/mapping/savefile.rs
@@ -5,11 +5,11 @@ use std::{
     sync::OnceLock,
 };
 
-use crate::mapping::{VfsKey, VfsOverride};
+use crate::mapping::{Generation, VfsKey, VfsOverride};
 
 pub struct SavefileOverrideMapping {
     savefile_dir: VfsKey,
-    override_path: OnceLock<(VfsOverride, VfsOverride)>,
+    override_path: OnceLock<(VfsOverride<'static>, VfsOverride<'static>)>,
     on_override: Box<dyn Fn(&Path) -> PathBuf + Send + Sync>,
 }
 
@@ -28,7 +28,7 @@ impl SavefileOverrideMapping {
     }
 
     #[inline]
-    pub fn try_override(&self, path: &Path, key: &VfsKey) -> Option<&VfsOverride> {
+    pub fn try_override(&self, path: &Path, key: &VfsKey) -> Option<&VfsOverride<'_>> {
         if path.extension() != Some(OsStr::new("bak")) {
             self.try_override_inner(path, key).map(|(sl2, _)| sl2)
         } else {
@@ -38,7 +38,11 @@ impl SavefileOverrideMapping {
     }
 
     #[inline]
-    fn try_override_inner(&self, path: &Path, key: &VfsKey) -> Option<&(VfsOverride, VfsOverride)> {
+    fn try_override_inner(
+        &self,
+        path: &Path,
+        key: &VfsKey,
+    ) -> Option<&(VfsOverride<'_>, VfsOverride<'_>)> {
         if path.extension() != Some(OsStr::new("sl2")) || !key.0.starts_with(&self.savefile_dir) {
             return None;
         }
@@ -52,9 +56,12 @@ impl SavefileOverrideMapping {
                 override_path
             };
 
+            let display = override_path.to_string_lossy().into_owned();
+            let display_bak = override_path_bak.to_string_lossy().into_owned();
+
             (
-                VfsOverride::new(override_path),
-                VfsOverride::new(override_path_bak),
+                VfsOverride::new(&override_path, Generation, display.into()),
+                VfsOverride::new(&override_path_bak, Generation, display_bak.into()),
             )
         }))
     }

--- a/crates/mod-host-assets/src/wwise.rs
+++ b/crates/mod-host-assets/src/wwise.rs
@@ -49,7 +49,10 @@ pub enum AkOpenMode {
 }
 
 /// Tries to find an override for a sound archive entry.
-pub fn find_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option<VfsOverride<'a>> {
+pub fn find_override<'a>(
+    mapping: &'a VfsOverrideMapping,
+    input: &str,
+) -> Option<&'a VfsOverride<'a>> {
     let input = strip_prefix(input);
     if input.ends_with(".wem") {
         let wem_path = format!("wem/{input}");
@@ -71,10 +74,10 @@ pub fn find_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option
     None
 }
 
-fn get_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option<VfsOverride<'a>> {
+fn get_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option<&'a VfsOverride<'a>> {
     for prefix in PREFIXES {
         let prefixed = format!("{prefix}/{input}");
-        if let Some(replacement) = mapping.vfs_override(&prefixed) {
+        if let Some(replacement) = mapping.virtual_to_disk(&prefixed) {
             return Some(replacement);
         }
     }

--- a/crates/mod-host-assets/src/wwise.rs
+++ b/crates/mod-host-assets/src/wwise.rs
@@ -49,7 +49,7 @@ pub enum AkOpenMode {
 }
 
 /// Tries to find an override for a sound archive entry.
-pub fn find_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option<&'a VfsOverride> {
+pub fn find_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option<VfsOverride<'a>> {
     let input = strip_prefix(input);
     if input.ends_with(".wem") {
         let wem_path = format!("wem/{input}");
@@ -71,7 +71,7 @@ pub fn find_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option
     None
 }
 
-fn get_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option<&'a VfsOverride> {
+fn get_override<'a>(mapping: &'a VfsOverrideMapping, input: &str) -> Option<VfsOverride<'a>> {
     for prefix in PREFIXES {
         let prefixed = format!("{prefix}/{input}");
         if let Some(replacement) = mapping.vfs_override(&prefixed) {

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -56,7 +56,7 @@ windows = { workspace = true, features = [
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
 ] }
-xxhash-rust = { version = "0.8", features = ["std", "xxh3"] }
+xxhash-rust.workspace = true
 pkcs1 = { version = "0.7.5", features = ["std"] }
 base64 = "0.22.1"
 miniz_oxide = { version = "0.9.0", features = ["std"] }

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -538,7 +538,7 @@ fn try_hook_wwise(
                 unsafe {
                     trampoline(
                         p1,
-                        mapped_override.into(),
+                        mapped_override.as_pcwstr(),
                         AkOpenMode::Read as _,
                         p4,
                         p5,

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -79,7 +79,7 @@ fn enable_loose_params(attach_config: &AttachConfig, mapping: &VfsOverrideMappin
 
     if LOOSE_PARAM_FILES
         .iter()
-        .any(|file| mapping.vfs_override(file).is_some())
+        .any(|file| mapping.virtual_to_disk(file).is_some())
     {
         ModHost::get_attached().override_game_property("Game.Debug.EnableRegulationFile", false);
     }
@@ -144,7 +144,7 @@ fn hook_ebl_utility(
             let expanded = unsafe { device_manager.expand_path(path.as_wide()) };
 
             if mapping
-                .vfs_override(OsString::from_wide(&expanded))
+                .virtual_to_disk(OsString::from_wide(&expanded))
                 .is_some()
             {
                 return None;
@@ -177,7 +177,7 @@ fn hook_device_manager(
             let path = path.get().ok()?;
             let expanded = DlDeviceManager::lock(device_manager).expand_path(path.as_slice());
 
-            let mapped_override = mapping.vfs_override(OsString::from_wide(&expanded))?;
+            let mapped_override = mapping.virtual_to_uid(OsString::from_wide(&expanded))?;
 
             info!("override" = %mapped_override);
 
@@ -250,7 +250,7 @@ fn hook_set_path(
 
         let expanded = DlDeviceManager::lock(device_manager).expand_path(path.as_slice());
 
-        let mapped_override = mapping.vfs_override(OsString::from_wide(&expanded))?;
+        let mapped_override = mapping.virtual_to_uid(OsString::from_wide(&expanded))?;
 
         let mut path = path.clone();
 

--- a/crates/mod-host/src/filesystem.rs
+++ b/crates/mod-host/src/filesystem.rs
@@ -93,7 +93,7 @@ fn hook_create_file(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Result<(),
                 }
 
                 if let Ok(path) = p1.to_string()
-                    && let Some(mapped_override) = mapping.disk_override(path)
+                    && let Some(mapped_override) = mapping.disk_or_uid_to_disk(path)
                 {
                     info!("override" = %mapped_override);
 
@@ -119,7 +119,7 @@ fn hook_create_file(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Result<(),
 
                 let path = OsString::from_wide(p1.as_wide());
 
-                if let Some(mapped_override) = mapping.disk_override(path) {
+                if let Some(mapped_override) = mapping.disk_or_uid_to_disk(path) {
                     info!("override" = %mapped_override);
 
                     return trampoline(mapped_override.into(), p2, p3, p4, p5, p6, p7);
@@ -143,7 +143,7 @@ fn hook_create_file(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Result<(),
 
                 let path = OsString::from_wide(p1.as_wide());
 
-                if let Some(mapped_override) = mapping.disk_override(path) {
+                if let Some(mapped_override) = mapping.disk_or_uid_to_disk(path) {
                     info!("override" = %mapped_override);
 
                     return trampoline(mapped_override.into(), p2, p3, p4, p5);
@@ -201,7 +201,7 @@ fn hook_create_directory(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Resul
                 if p1.is_null() {
                     trampoline(p1, p2)
                 } else if let Ok(path) = p1.to_string()
-                    && let Some(mapped_override) = mapping.disk_override(path)
+                    && let Some(mapped_override) = mapping.disk_or_uid_to_disk(path)
                 {
                     let c_string = mapped_override.to_c_string();
                     trampoline(PCSTR(c_string.as_ptr()), p2)
@@ -221,7 +221,7 @@ fn hook_create_directory(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Resul
                 if p1.is_null() {
                     trampoline(p1, p2)
                 } else if let Some(mapped_override) =
-                    mapping.disk_override(OsString::from_wide(p1.as_wide()))
+                    mapping.disk_or_uid_to_disk(OsString::from_wide(p1.as_wide()))
                 {
                     trampoline(mapped_override.into(), p2)
                 } else {
@@ -240,7 +240,7 @@ fn hook_create_directory(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Resul
                 if p1.is_null() {
                     trampoline(p1, p2, p3)
                 } else if let Some(mapped_override) =
-                    mapping.disk_override(OsString::from_wide(p1.as_wide()))
+                    mapping.disk_or_uid_to_disk(OsString::from_wide(p1.as_wide()))
                 {
                     trampoline(mapped_override.into(), p2, p3)
                 } else {
@@ -281,7 +281,7 @@ fn hook_delete_file(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Result<(),
                 if p1.is_null() {
                     trampoline(p1)
                 } else if let Ok(path) = p1.to_string()
-                    && let Some(mapped_override) = mapping.disk_override(path)
+                    && let Some(mapped_override) = mapping.disk_or_uid_to_disk(path)
                 {
                     let c_string = mapped_override.to_c_string();
                     trampoline(PCSTR(c_string.as_ptr()))
@@ -301,7 +301,7 @@ fn hook_delete_file(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Result<(),
                 if p1.is_null() {
                     trampoline(p1)
                 } else if let Some(mapped_override) =
-                    mapping.disk_override(OsString::from_wide(p1.as_wide()))
+                    mapping.disk_or_uid_to_disk(OsString::from_wide(p1.as_wide()))
                 {
                     trampoline(mapped_override.into())
                 } else {

--- a/crates/mod-host/src/filesystem.rs
+++ b/crates/mod-host/src/filesystem.rs
@@ -97,7 +97,8 @@ fn hook_create_file(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Result<(),
                 {
                     info!("override" = %mapped_override);
 
-                    return trampoline(mapped_override.into(), p2, p3, p4, p5, p6, p7);
+                    let c_string = mapped_override.to_c_string();
+                    return trampoline(PCSTR(c_string.as_ptr()), p2, p3, p4, p5, p6, p7);
                 }
 
                 trampoline(p1, p2, p3, p4, p5, p6, p7)
@@ -202,7 +203,8 @@ fn hook_create_directory(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Resul
                 } else if let Ok(path) = p1.to_string()
                     && let Some(mapped_override) = mapping.disk_override(path)
                 {
-                    trampoline(mapped_override.into(), p2)
+                    let c_string = mapped_override.to_c_string();
+                    trampoline(PCSTR(c_string.as_ptr()), p2)
                 } else {
                     trampoline(p1, p2)
                 }
@@ -281,7 +283,8 @@ fn hook_delete_file(kb: HMODULE, mapping: Arc<VfsOverrideMapping>) -> Result<(),
                 } else if let Ok(path) = p1.to_string()
                     && let Some(mapped_override) = mapping.disk_override(path)
                 {
-                    trampoline(mapped_override.into())
+                    let c_string = mapped_override.to_c_string();
+                    trampoline(PCSTR(c_string.as_ptr()))
                 } else {
                     trampoline(p1)
                 }


### PR DESCRIPTION
Fixes #804

Uses a fake UNC path prefix `\\me3` to indicate disk file paths internally managed by me3. This is a significant change to how file paths are handled and seen by the game and I would like this to be tested thoroughly before merging.

Elden Ring (and likely the other games) forward file paths converted from UTF-16 to Shift JIS to the Scaleform UI middleware (which expects UTF-8). This conversion can only be valid for the ASCII subset of UTF and SJIS, and user paths that contain other characters are silently truncated at the first character that failed to be converted. What's worse is that the failed conversion does not nul-terminate the string.

The conversion happens at `eldenring.exe+d7106d` (1.16.2) and the subsequent call consumes the string.

The implementation in this PR leaves room for a future file reloading feature (with generation based indexing).