### PR TITLE
Add Proton launch verb override via env variable

### DIFF
--- a/crates/cli/src/commands/launch/strategy/compat_tool.rs
+++ b/crates/cli/src/commands/launch/strategy/compat_tool.rs
@@ -223,7 +223,13 @@ impl LaunchStrategy for CompatToolLaunchStrategy {
             ..
         } = self;
 
-        const LAUNCH_VERB: &str = "waitforexitandrun";
+        let launch_verb = std::env::var("ME3_PROTON_LAUNCH_VERB")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "waitforexitandrun".to_string());
+
+        info!(%launch_verb, "using Proton launch verb");
         let mut tool_paths = vec![];
 
         loop {
@@ -231,7 +237,7 @@ impl LaunchStrategy for CompatToolLaunchStrategy {
             let tool_manifest = tool.manifest()?;
             let tool_command = match tool_manifest.version {
                 1 => tool_manifest.commandline.clone(),
-                2 | _ => tool_manifest.commandline.replace("%verb%", LAUNCH_VERB),
+                2 | _ => tool_manifest.commandline.replace("%verb%", &launch_verb),
             };
 
             let Some(mut tool_args) = shlex::split(&tool_command) else {


### PR DESCRIPTION
When `waitforexitandrun` is used, `wineserver -w` waits until all Wine processes in the prefix exit. If you have a pre-launched tool running, such as cheat engine or a randomizer configurator, the game launch hangs waiting for that tool to close. Allowing the launch verb to be overridden to  `run` skips this wait, allowing the game to launch immediately alongside the running tool in the same wineserver.