### PR TITLE
chore: Release v0.11.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,11 +22,11 @@ body:
       description: What version of our software are you running?
       options:
         - prerelease
+        - v0.11.1
         - v0.11.0
         - v0.10.1
         - v0.10.0
         - v0.9.0
-        - v0.8.1
       default: 1
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,13 @@ jobs:
           set -x
           echo "current_version=v$(cargo pkgid -p me3-mod-host | cut -d '@' -f2)" >> "$GITHUB_OUTPUT"
           echo "next_version=$(git cliff --bumped-version --unreleased)" >> "$GITHUB_OUTPUT"
-        
+
   create-release-draft:
     needs:
       - plan
     name: Prerelease
     permissions:
+      actions: read
       contents: read
       pull-requests: write
       id-token: write
@@ -54,7 +55,7 @@ jobs:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
         with:
-          egress-policy: audit      
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -64,7 +65,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: stable
-          targets: x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu          
+          targets: x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu
 
       - uses: taiki-e/install-action@9ca1734d8940023f074414ee621fd530c4ce10f2 # v2.55.3
         with:
@@ -77,21 +78,21 @@ jobs:
 
       - name: Bump versions
         run: |
-            # Bump Cargo workspace crates
-            cargo set-version "${NEXT_VERSION:1}" # strip the leading 'v'
-            cargo update --workspace
+          # Bump Cargo workspace crates
+          cargo set-version "${NEXT_VERSION:1}" # strip the leading 'v'
+          cargo update --workspace
 
-            # Update version in Linux installer
-            sed -i "s/INSTALLER_VERSION=.*/INSTALLER_VERSION=$NEXT_VERSION/" installer.sh
+          # Update version in Linux installer
+          sed -i "s/INSTALLER_VERSION=.*/INSTALLER_VERSION=$NEXT_VERSION/" installer.sh
 
-            # Update changelog
-            git cliff --tag "$NEXT_VERSION" -o CHANGELOG.md
+          # Update changelog
+          git cliff --tag "$NEXT_VERSION" -o CHANGELOG.md
 
-            # Bump bug report template
-            yq -i '(.body[] | select(.id == "version").attributes.options) |= .[0:1] + ["'"$NEXT_VERSION"'"] + .[1:5]' .github/ISSUE_TEMPLATE/bug-report.yml
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
-            git config --global user.name "github-actions"
-            git commit -am "chore: Release $NEXT_VERSION"
+          # Bump bug report template
+          yq -i '(.body[] | select(.id == "version").attributes.options) |= .[0:1] + ["'"$NEXT_VERSION"'"] + .[1:5]' .github/ISSUE_TEMPLATE/bug-report.yml
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions"
+          git commit -am "chore: Release $NEXT_VERSION"
         env:
           NEXT_VERSION: ${{ needs.plan.outputs.next_version }}
 
@@ -101,13 +102,28 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-      - name: Sign binaries
-        uses: ./.github/actions/sign-authenticode
+      - name: Upload unsigned binaries
+        id: upload-unsigned-binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          files: out/me3.exe out/me3-launcher.exe out/me3_mod_host.dll
-          cloudflare_client_id: ${{ secrets.CLOUDFLARE_ZEROTRUST_CLIENT_ID }}
-          cloudflare_client_secret: ${{ secrets.CLOUDFLARE_ZEROTRUST_CLIENT_SECRET }}
-          signing_pin: ${{ secrets.ME3_SIGNING_PIN }}
+          name: unsigned-binaries
+          path: |
+            out/me3.exe
+            out/me3-launcher.exe
+            out/me3_mod_host.dll
+          if-no-files-found: error
+
+      - name: Sign binaries
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: "2da12aff-ebaa-4418-af85-f0fc2df74452"
+          project-slug: "me3"
+          signing-policy-slug: "test-signing"
+          artifact-configuration-slug: "initial"
+          github-artifact-id: ${{ steps.upload-unsigned-binaries.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: out
 
       - name: Create distributions and installer
         run: |
@@ -115,13 +131,25 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-      - name: Sign installer
-        uses: ./.github/actions/sign-authenticode
+      - name: Upload unsigned installer
+        id: upload-unsigned-installer
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          files: out/me3_installer.exe
-          cloudflare_client_id: ${{ secrets.CLOUDFLARE_ZEROTRUST_CLIENT_ID }}
-          cloudflare_client_secret: ${{ secrets.CLOUDFLARE_ZEROTRUST_CLIENT_SECRET }}
-          signing_pin: ${{ secrets.ME3_SIGNING_PIN }}
+          name: unsigned-installer
+          path: out/me3_installer.exe
+          if-no-files-found: error
+
+      - name: Sign installer
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: "2da12aff-ebaa-4418-af85-f0fc2df74452"
+          project-slug: "me3"
+          signing-policy-slug: "test-signing"
+          artifact-configuration-slug: "initial"
+          github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: out
 
       - uses: actions/attest-build-provenance@v3
         id: attestation
@@ -135,13 +163,13 @@ jobs:
       - name: Delete old release drafts
         uses: hugo19941994/delete-draft-releases@v2.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PUSH_TOKEN }}            
+          GITHUB_TOKEN: ${{ secrets.PUSH_TOKEN }}
         with:
           threshold: "1s"
 
       - name: Create zip file of debug info
         run: |
-          find out \( -name '*.pdb' -or -name '*.debug' \) -print | zip -j out/me3-debug-info.zip -@ 
+          find out \( -name '*.pdb' -or -name '*.debug' \) -print | zip -j out/me3-debug-info.zip -@
 
       - name: Create release draft
         run: | # shell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           organization-id: "2da12aff-ebaa-4418-af85-f0fc2df74452"
           project-slug: "me3"
           signing-policy-slug: "test-signing"
-          artifact-configuration-slug: "initial"
+          artifact-configuration-slug: "distributables"
           github-artifact-id: ${{ steps.upload-unsigned-binaries.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: out
@@ -146,7 +146,7 @@ jobs:
           organization-id: "2da12aff-ebaa-4418-af85-f0fc2df74452"
           project-slug: "me3"
           signing-policy-slug: "test-signing"
-          artifact-configuration-slug: "initial"
+          artifact-configuration-slug: "installer"
           github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 <!-- markdown-link-check-disable -->
 <!-- ignore lint rules that are often triggered by content generated from commits / git-cliff -->
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
+## me3 - [v0.11.1](https://github.com/garyttierney/me3/releases/v0.11.1) - 2026-07-06
+
+### 🐛 Bug Fixes
+
+- [c998b06](https://github.com/garyttierney/me3/commit/c998b06cc53c35794aa9808480ecfb2ac6a2fb60)  *(linux)* Restore LD_PRELOAD injection for Steam overlay in compat tool launcher in [#735](https://github.com/garyttierney/me3/pull/735)
+
+
+  > In `compat_tool.rs`, `setup_steam_linux_runtime_env` builds `LD_PRELOAD`
+  > with `gameoverlayrenderer.so` but never sets it on the command, restore it
+  > to fix Steam Input compatibility and the Steam overlay.
+
 ## me3 - [v0.11.0](https://github.com/garyttierney/me3/releases/v0.11.0) - 2026-02-28
 
 ### 🚀 Features
@@ -2756,6 +2767,7 @@ All notable changes to this project will be documented in this file.
 - [c4e6ef5](https://github.com/garyttierney/me3/commit/c4e6ef502776db75d89dbfef6c585b658a28caf4) Initial commit
 
 
+[0.11.1]: https://github.com/garyttierney/me3/compare/v0.11.0..v0.11.1
 [0.11.0]: https://github.com/garyttierney/me3/compare/v0.9.0..v0.11.0
 [0.9.0]: https://github.com/garyttierney/me3/compare/v0.8.1..v0.9.0
 [0.8.1]: https://github.com/garyttierney/me3/compare/v0.7.0..v0.8.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "me3-binary-analysis"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "pelite",
  "rayon",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "assert_fs",
  "base64",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "me3-env"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "me3-mod-protocol",
  "serde",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "me3-ipc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "me3-env",
  "me3-launcher-attach-protocol",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "eyre",
  "me3-env",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "eyre",
  "me3-mod-protocol",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "base64",
  "closure-ffi",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "from-singleton",
  "libc",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-types"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "me3-binary-analysis",
  "me3-env",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "expect-test",
  "indexmap",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "color-eyre",
  "eyre",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.11.0"
+version = "0.11.1"
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/binary-analysis/Cargo.toml
+++ b/crates/binary-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-binary-analysis"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-cli"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-env"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/ipc/Cargo.toml
+++ b/crates/ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-ipc"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher-attach-protocol/Cargo.toml
+++ b/crates/launcher-attach-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher-attach-protocol"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-assets"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-types/Cargo.toml
+++ b/crates/mod-host-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-types"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-protocol"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3_telemetry"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039  # local is non-POSIX
 set -u
 
-INSTALLER_VERSION=v0.11.0
+INSTALLER_VERSION=v0.11.1
 
 need_cmd() {
     if ! check_cmd "$1"; then


### PR DESCRIPTION

## [unreleased]

### 🐛 Bug Fixes

- [c998b06](https://github.com/garyttierney/me3/commit/c998b06cc53c35794aa9808480ecfb2ac6a2fb60)  *(linux)* Restore LD_PRELOAD injection for Steam overlay in compat tool launcher in [#735](https://github.com/garyttierney/me3/pull/735)


  > In `compat_tool.rs`, `setup_steam_linux_runtime_env` builds `LD_PRELOAD`
  > with `gameoverlayrenderer.so` but never sets it on the command, restore it
  > to fix Steam Input compatibility and the Steam overlay.