### PR TITLE
refactor(host): don't use hook to set game properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,7 @@ dependencies = [
 name = "me3-binary-analysis"
 version = "0.11.0"
 dependencies = [
+ "memchr",
  "pelite",
  "rayon",
  "regex",
@@ -1771,6 +1772,7 @@ dependencies = [
  "me3-mod-host-types",
  "me3-mod-protocol",
  "me3_telemetry",
+ "memchr",
  "miniz_oxide 0.9.0",
  "pelite",
  "pkcs1",
@@ -1857,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ me3-mod-host-types = { path = "crates/mod-host-types" }
 me3-mod-protocol = { path = "crates/mod-protocol" }
 me3-telemetry = { package = "me3_telemetry", path = "crates/telemetry" }
 memmap = "0.7"
+memchr = "2.8.2"
 normpath = "1"
 pelite = "0.10"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ strum_macros = "0.27"
 tempfile = "3"
 thiserror = "2"
 toml = { version = "0.9.11", features = ["preserve_order"] }
-tracing = { version = "0.1", features = ["release_max_level_info"] }
+tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false }
 ureq = { version = "3", default-features = false, features = ["native-tls"] }

--- a/crates/binary-analysis/Cargo.toml
+++ b/crates/binary-analysis/Cargo.toml
@@ -12,6 +12,7 @@ pelite.workspace = true
 rayon.workspace = true
 regex.workspace = true
 thiserror.workspace = true
+memchr.workspace = true
 undname = "2.1"
 
 [lints]

--- a/crates/binary-analysis/src/dlrf.rs
+++ b/crates/binary-analysis/src/dlrf.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use crate::pe::sections;
 
 #[derive(Debug, Clone, Copy)]
+#[repr(C)]
 pub struct RuntimeClassEntry {
     pub type_id: Va,
     pub class: Ptr<()>,

--- a/crates/binary-analysis/src/dlrf.rs
+++ b/crates/binary-analysis/src/dlrf.rs
@@ -1,0 +1,87 @@
+use pelite::{
+    pe::{Pe, Ptr, Rva, Va},
+    Pod,
+};
+use thiserror::Error;
+
+use crate::pe::sections;
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeClassEntry {
+    pub type_id: Va,
+    pub class: Ptr<()>,
+}
+
+unsafe impl Pod for RuntimeClassEntry {}
+
+#[derive(Debug, Error)]
+pub enum RuntimeClassesError {
+    #[error(transparent)]
+    Pelite(#[from] pelite::Error),
+    #[error("PE section \"{0}\" is missing")]
+    Section(&'static str),
+    #[error("RuntimeClass registry not found")]
+    NotFound,
+}
+
+/// Scan an initialized game's .data section, returning the DLRuntimeClass registry.
+///
+/// This is a slice of [`RuntimeClassEntry`], sorted by type ID.
+pub fn runtime_classes<'a, P: Pe<'a>>(
+    program: P,
+) -> Result<&'a [RuntimeClassEntry], RuntimeClassesError> {
+    let [data, rdata] =
+        sections(program, [".data", ".rdata"]).map_err(RuntimeClassesError::Section)?;
+
+    let data_virtual_range = data.virtual_range();
+    let rdata_virtual_range = rdata.virtual_range();
+
+    let data_range =
+        program.rva_to_va(data_virtual_range.start)?..program.rva_to_va(data_virtual_range.end)?;
+    let rdata_range = program.rva_to_va(rdata_virtual_range.start)?
+        ..program.rva_to_va(rdata_virtual_range.end)?;
+
+    let mut best_run = 0;
+    let mut best_start = None;
+
+    let mut current_run = 0;
+    let mut current_start = 0;
+    let mut last_type_id = 0;
+
+    const ENTRY_SIZE: usize = size_of::<RuntimeClassEntry>();
+
+    for rva in data_virtual_range.step_by(ENTRY_SIZE) {
+        let type_id: Ptr<u8> = *program.derva(rva)?;
+        let rtc_ptr: Ptr<Va> = *program.derva(rva + size_of::<Va>() as Rva)?;
+
+        let is_valid = type_id.into_raw() > last_type_id
+            && data_range.contains(&type_id.into_raw())
+            && data_range.contains(&rtc_ptr.into_raw())
+            && program.deref(type_id) == Ok(&0)
+            && program
+                .deref(rtc_ptr)
+                .is_ok_and(|vmt| rdata_range.contains(vmt));
+
+        if is_valid {
+            current_run += 1;
+            last_type_id = type_id.into_raw();
+            if current_run > best_run {
+                best_start = Some(current_start);
+                best_run = current_run;
+            }
+        } else {
+            current_run = 0;
+            last_type_id = 0;
+            current_start = rva + ENTRY_SIZE as Rva;
+        }
+    }
+
+    // To guard against the registry structure being changed in the future,
+    // expect at least 512 runtime classes. All have over 4000, so
+    // this seems reasonable.
+    let registry_rva = best_start
+        .filter(|_| best_run >= 512)
+        .ok_or(RuntimeClassesError::NotFound)?;
+
+    Ok(program.derva_slice(registry_rva, best_run)?)
+}

--- a/crates/binary-analysis/src/lib.rs
+++ b/crates/binary-analysis/src/lib.rs
@@ -2,3 +2,4 @@ pub mod dlrf;
 pub mod fd4_step;
 pub mod pe;
 pub mod rtti;
+pub mod util;

--- a/crates/binary-analysis/src/lib.rs
+++ b/crates/binary-analysis/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod dlrf;
 pub mod fd4_step;
 pub mod pe;
 pub mod rtti;

--- a/crates/binary-analysis/src/util.rs
+++ b/crates/binary-analysis/src/util.rs
@@ -19,13 +19,15 @@ pub fn lea_refs<'a, P: Pe<'a>>(program: P, target: Rva) -> pelite::Result<Vec<Rv
         let target_rel = target.wrapping_sub(section_rva);
 
         let section_slice = program.get_section_bytes(section)?;
+        // We scan for the LEA opcode, which is after the REX prefix, so start at 1.
+        // The entire instruction is 7 bytes, so ignore the last 6 byte positions.
         let scan_slice = &section_slice[1..section_slice.len() - 6];
-
+        // We can't use `chunks(PAR_CHUNK_USIZE)` here, since we need the index too.
         let par_split = (0..scan_slice.len()).step_by(PAR_CHUNK_SIZE).par_bridge();
-
         let section_results = par_split
             .flat_map_iter(|start| {
-                let end = scan_slice.len().min(start + PAR_CHUNK_SIZE + 6);
+                let end = scan_slice.len().min(start + PAR_CHUNK_SIZE);
+                // Use memchr to search for the LEA opcode (0x8d).
                 memchr::memchr_iter(0x8d, &scan_slice[start..end]).filter_map(move |i| {
                     let lea_candidate = start + i;
                     let instr_start = lea_candidate;

--- a/crates/binary-analysis/src/util.rs
+++ b/crates/binary-analysis/src/util.rs
@@ -1,0 +1,57 @@
+use pelite::pe::{Pe, Rva};
+use rayon::iter::{ParallelBridge, ParallelIterator};
+
+/// Find rip-relative LEA instructions that target the given RVA.
+pub fn lea_refs<'a, P: Pe<'a>>(program: P, target: Rva) -> pelite::Result<Vec<Rva>> {
+    // Manually parallelize over 64KiB blocks.
+    //
+    // Benchmarking shows that perf doesn't degrade unless blocks are very small
+    // (<4096 bytes) or so large that available parallelism is underused.
+    const PAR_CHUNK_SIZE: usize = 0x10000;
+
+    let mut results = Vec::new();
+    for section in program.section_headers() {
+        if section.name_bytes() != b".text" {
+            continue;
+        }
+
+        let section_rva = section.VirtualAddress;
+        let target_rel = target.wrapping_sub(section_rva);
+
+        let section_slice = program.get_section_bytes(section)?;
+        let scan_slice = &section_slice[1..section_slice.len() - 6];
+
+        let par_split = (0..scan_slice.len()).step_by(PAR_CHUNK_SIZE).par_bridge();
+
+        let section_results = par_split
+            .flat_map_iter(|start| {
+                let end = scan_slice.len().min(start + PAR_CHUNK_SIZE + 6);
+                memchr::memchr_iter(0x8d, &scan_slice[start..end]).filter_map(move |i| {
+                    let lea_candidate = start + i;
+                    let instr_start = lea_candidate;
+                    let modrm = lea_candidate + 2;
+                    let disp_start = lea_candidate + 3;
+                    let instr_end = lea_candidate + 7;
+
+                    // Check REX byte, masking REX.B
+                    if (section_slice[instr_start] & 0b1111_1011) != 0x48 {
+                        return None;
+                    }
+                    // Check Mod.RM byte, masking REG
+                    if (section_slice[modrm] & 0b1100_0111) != 5 {
+                        return None;
+                    }
+                    // Check displacement
+                    let disp_slice = &section_slice[disp_start..instr_end];
+                    let disp = i32::from_le_bytes(disp_slice.try_into().unwrap());
+                    ((instr_end as Rva).wrapping_add_signed(disp) == target_rel)
+                        .then(|| section_rva + instr_start as Rva)
+                })
+            })
+            .collect_vec_list();
+
+        results.extend(section_results.into_iter().flatten());
+    }
+
+    Ok(results)
+}

--- a/crates/mod-host-types/src/dlrf.rs
+++ b/crates/mod-host-types/src/dlrf.rs
@@ -30,6 +30,7 @@ impl DLTypeId {
 }
 
 #[derive(Debug)]
+#[repr(C)]
 pub struct DLRuntimeClassVtable<T> {
     pub dtor: unsafe extern "C" fn(*mut T),
     pub name: extern "C" fn(&T) -> ThinCStr,
@@ -248,7 +249,8 @@ impl<'a> RuntimeClassEntry<'a> {
     pub unsafe fn from_analysis(
         registry: &'a [me3_binary_analysis::dlrf::RuntimeClassEntry],
     ) -> &'a [Self] {
-        unsafe { std::mem::transmute(registry) }
+        // SAFETY: RuntimeClassEntry of both modules is ABI compatible.
+        unsafe { std::slice::from_raw_parts(registry.as_ptr() as *const _, registry.len()) }
     }
 }
 

--- a/crates/mod-host-types/src/dlrf.rs
+++ b/crates/mod-host-types/src/dlrf.rs
@@ -1,0 +1,273 @@
+//! DLRF runtime reflection system.
+//!
+//! Credit for the bulk of this reverse engineering work goes to [Axi](https://github.com/axd1x8a).
+
+use std::{fmt, mem::MaybeUninit, ops::Deref};
+
+use crate::{
+    alloc::DlAllocator,
+    ffi::{ThinCStr, ThinWCStr},
+    vector::DlVector,
+};
+
+/// Unique type identifier for types registered into DLRF.
+///
+/// These are generated using template metaprogramming, and actually represent the address
+/// of unique static `u8` with a value of 0, instantiated per type. Hence a valid [`DLTypeId`]
+/// is inherently non-zero.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DLTypeId(pub usize);
+
+impl DLTypeId {
+    /// A [`DLTypeId`] that does not represent an actual type.
+    pub const NONE: Self = Self(0);
+
+    /// Whether this [`DLTypeId`] represents an actual type.
+    pub const fn is_none(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+#[derive(Debug)]
+pub struct DLRuntimeClassVtable<T> {
+    pub dtor: unsafe extern "C" fn(*mut T),
+    pub name: extern "C" fn(&T) -> ThinCStr,
+    pub name_wide: extern "C" fn(&T) -> ThinWCStr,
+    pub type_id: extern "C" fn(&T) -> DLTypeId,
+    pub const_type_id: extern "C" fn(&T) -> DLTypeId,
+    pub ptr_type_id: extern "C" fn(&T) -> DLTypeId,
+    pub const_ptr_type_id: extern "C" fn(&T) -> DLTypeId,
+    pub is_primitive_type: extern "C" fn(&T) -> bool,
+    pub destruct: unsafe extern "C" fn(&T, instance: *mut (), allocator: *mut DlAllocator),
+    pub flags: extern "C" fn(&T) -> u32,
+    pub register_runtime_ctor:
+        unsafe extern "C" fn(&mut T, invoker: *const (), name: ThinCStr, name_wide: ThinWCStr),
+    pub register_method_invoker: unsafe extern "C" fn(
+        &mut T,
+        invoker: *const DLConcreteMethodInvoker,
+        name: ThinCStr,
+        name_wide: ThinWCStr,
+    ),
+}
+
+#[repr(C)]
+pub struct DLRuntimeClassImpl<'a> {
+    vtable: &'a DLRuntimeClassVtable<Self>,
+    pub parent: Option<&'a Self>,
+    pub runtime_ctor: Option<&'a DLRuntimeMethod<'a>>,
+    pub methods: DlVector<DLRuntimeClassMethodInvoker<'a>>,
+    pub name: ThinCStr<'a>,
+    pub name_wide: ThinWCStr<'a>,
+}
+
+impl<'a> DLRuntimeClassImpl<'a> {
+    pub fn vtable(&self) -> &'a DLRuntimeClassVtable<Self> {
+        self.vtable
+    }
+
+    pub fn type_id(&self) -> DLTypeId {
+        (self.vtable.type_id)(self)
+    }
+
+    pub fn const_type_id(&self) -> DLTypeId {
+        (self.vtable.const_type_id)(self)
+    }
+
+    pub fn ptr_type_id(&self) -> DLTypeId {
+        (self.vtable.ptr_type_id)(self)
+    }
+
+    pub fn const_ptr_type_id(&self) -> DLTypeId {
+        (self.vtable.const_ptr_type_id)(self)
+    }
+
+    pub fn is_primitive_type(&self) -> bool {
+        (self.vtable.is_primitive_type)(self)
+    }
+}
+
+impl fmt::Debug for DLRuntimeClassImpl<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DLRuntimeClassImpl")
+            .field("vmt", &(self.vtable as *const _))
+            .field("parent", &self.parent)
+            .field("runtime_ctor", &self.runtime_ctor)
+            .field("methods", &self.methods)
+            .field("name", &self.name)
+            .field("name_wide", &self.name_wide)
+            .finish()
+    }
+}
+
+#[repr(C)]
+pub struct DLRuntimeMethod<'a> {
+    pub class: &'a DLRuntimeClassImpl<'a>,
+    pub name: Option<ThinCStr<'a>>,
+    pub name_wide: Option<ThinWCStr<'a>>,
+    dl_mutex: [u8; 0x30],
+    pub addr: *const (),
+}
+
+impl fmt::Debug for DLRuntimeMethod<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DLRuntimeMethod")
+            .field("class", &(self.class as *const _))
+            .field("name", &self.name)
+            .field("name_wide", &self.name_wide)
+            .field("addr", &self.addr)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct DLRuntimeClassMethodInvoker<'a> {
+    pub resolver: &'a DLMethodResolver<'a>,
+    pub name: ThinCStr<'a>,
+    pub name_wide: ThinWCStr<'a>,
+    pub name_len: usize,
+}
+
+#[repr(C)]
+pub struct DLMethodResolver<'a> {
+    pub class: &'a DLRuntimeClassImpl<'a>,
+    pub name: ThinCStr<'a>,
+    pub name_wide: ThinWCStr<'a>,
+    pub invokers: DlVector<&'a DLConcreteMethodInvoker<'a>>,
+    // fields below are no longer populated.
+    _param_infos: DlVector<DLParameterInfo<'a>>,
+    _loose_param_info_start: Option<&'a DLParameterInfo<'a>>,
+}
+
+impl fmt::Debug for DLMethodResolver<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DLMethodResolver")
+            .field("class", &(self.class as *const _))
+            .field("name", &self.name)
+            .field("name_wide", &self.name_wide)
+            .field("invokers", &self.invokers)
+            // .field("param_infos", &self._param_infos)
+            // .field("loose_param_info_start", &self._loose_param_info_start)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct DLMethodInvokerVtable<T> {
+    pub invoke: *const (), // signature not reversed yet.
+    pub dtor: unsafe extern "C" fn(*mut T),
+    pub param_count: extern "C" fn(&T) -> u32,
+    pub strict_param_info: for<'a> extern "C" fn(&'a T, out: &mut MaybeUninit<DLParameterInfo<'a>>),
+    pub loose_param_info: for<'a> extern "C" fn(&'a T, out: &mut MaybeUninit<DLParameterInfo<'a>>),
+    pub return_type: extern "C" fn(&T) -> DLTypeId,
+}
+
+#[repr(C)]
+pub struct DLConcreteMethodInvoker<'a> {
+    vtable: &'a DLMethodInvokerVtable<Self>,
+    pub addr: *const (),
+}
+
+impl<'a> DLConcreteMethodInvoker<'a> {
+    pub fn vtable(&self) -> &'a DLMethodInvokerVtable<Self> {
+        self.vtable
+    }
+
+    pub fn param_count(&self) -> u32 {
+        (self.vtable.param_count)(self)
+    }
+
+    /// Get all mandatory parameters to this function.
+    pub fn strict_param_info(&self) -> DLParameterInfo<'_> {
+        let mut param_info = MaybeUninit::uninit();
+        (self.vtable.strict_param_info)(self, &mut param_info);
+        unsafe { param_info.assume_init() }
+    }
+
+    /// Get all parameters to this function, including optional ones.
+    pub fn loose_param_info(&self) -> DLParameterInfo<'_> {
+        let mut param_info = MaybeUninit::uninit();
+        (self.vtable.loose_param_info)(self, &mut param_info);
+        unsafe { param_info.assume_init() }
+    }
+
+    pub fn return_type(&self) -> DLTypeId {
+        (self.vtable.return_type)(self)
+    }
+}
+
+impl fmt::Debug for DLConcreteMethodInvoker<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DLConcreteMethodInvoker")
+            .field(&self.addr)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct DLParameterInfo<'a> {
+    params: [DLTypeId; 15],
+    pub method_invoker: &'a DLConcreteMethodInvoker<'a>,
+}
+
+impl DLParameterInfo<'_> {
+    pub fn params(&self) -> &[DLTypeId] {
+        &self.params[..self.method_invoker.param_count() as usize]
+    }
+}
+
+impl Deref for DLParameterInfo<'_> {
+    type Target = [DLTypeId];
+
+    fn deref(&self) -> &Self::Target {
+        self.params()
+    }
+}
+
+/// Entry in the runtime class registry.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct RuntimeClassEntry<'a> {
+    /// The type ID of this class. May also be the type-ID for the const class, or a pointer to the
+    /// class.
+    pub type_id: DLTypeId,
+    /// The associated runtime class information.
+    pub class: &'a DLRuntimeClassImpl<'a>,
+}
+
+impl<'a> RuntimeClassEntry<'a> {
+    /// Construct a slice of [`RuntimeClassEntry`] from analysis output.
+    ///
+    /// # Safety
+    ///
+    /// - `registry` must be sourced from [`me3_binary_analysis::dlrf::runtime_classes`].
+    /// - The program passed to the above function must be a view over a real game executable.
+    pub unsafe fn from_analysis(
+        registry: &'a [me3_binary_analysis::dlrf::RuntimeClassEntry],
+    ) -> &'a [Self] {
+        unsafe { std::mem::transmute(registry) }
+    }
+}
+
+impl PartialEq for RuntimeClassEntry<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_id == other.type_id
+    }
+}
+
+impl Eq for RuntimeClassEntry<'_> {}
+
+impl PartialOrd for RuntimeClassEntry<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RuntimeClassEntry<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.type_id.cmp(&other.type_id)
+    }
+}

--- a/crates/mod-host-types/src/ffi.rs
+++ b/crates/mod-host-types/src/ffi.rs
@@ -1,0 +1,6 @@
+//! Generic FFI-related types that are not specific to FromSoftware games.
+
+pub mod thin_cstr;
+
+#[doc(inline)]
+pub use thin_cstr::{ThinCStr, ThinWCStr};

--- a/crates/mod-host-types/src/ffi/thin_cstr.rs
+++ b/crates/mod-host-types/src/ffi/thin_cstr.rs
@@ -16,6 +16,9 @@ use std::{
 #[derive(Clone, Copy)]
 pub struct ThinCStr<'a>(NonNull<c_char>, PhantomData<&'a ()>);
 
+unsafe impl Send for ThinCStr<'_> {}
+unsafe impl Sync for ThinCStr<'_> {}
+
 impl<'a> ThinCStr<'a> {
     /// Construct a [`ThinCStr`] from a [`CStr`] ref.
     pub fn from_cstr(cstr: &'a CStr) -> Self {
@@ -92,6 +95,9 @@ impl Eq for ThinCStr<'_> {}
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct ThinWCStr<'a>(NonNull<u16>, PhantomData<&'a ()>);
+
+unsafe impl Send for ThinWCStr<'_> {}
+unsafe impl Sync for ThinWCStr<'_> {}
 
 impl ThinWCStr<'_> {
     /// Construct a [`ThinWStr`] from a pointer to a nul-terminated wide C string.
@@ -172,37 +178,7 @@ impl AsRef<[u16]> for ThinWCStr<'_> {
 
 impl fmt::Debug for ThinWCStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use fmt::Write;
-
-        let mut char_iter = char::decode_utf16(self.to_wchars().iter().copied())
-            .map(|c| c.unwrap_or(char::REPLACEMENT_CHARACTER));
-
-        // A Debug representation for a string should be escaped. Instead of
-        // reimplementing the escaping logic, we convert to utf-8 first so the
-        // Debug impl of str can be used.
-        let mut stack_str = [0u8; 128];
-        let mut stack_str_len = 0;
-        let mut heap_str;
-        let lossy_str = loop {
-            if let Some(c) = char_iter.next() {
-                // Possibly not enough space to encode the next character,
-                // fall back to a heap-allocated string.
-                if stack_str_len > stack_str.len() - 4 {
-                    heap_str =
-                        unsafe { String::from_utf8_unchecked(stack_str[..stack_str_len].into()) };
-                    heap_str.write_char(c)?;
-                    for c in char_iter {
-                        heap_str.write_char(c)?;
-                    }
-                    break heap_str.as_str();
-                }
-                stack_str_len += c.encode_utf8(&mut stack_str[stack_str_len..]).len();
-            } else {
-                break unsafe { str::from_utf8_unchecked(&stack_str[..stack_str_len]) };
-            }
-        };
-
-        std::fmt::Debug::fmt(lossy_str, f)
+        std::fmt::Debug::fmt(&self.to_string_lossy(), f)
     }
 }
 

--- a/crates/mod-host-types/src/ffi/thin_cstr.rs
+++ b/crates/mod-host-types/src/ffi/thin_cstr.rs
@@ -1,0 +1,221 @@
+//! Thin C string types that are ffi-compatible with thin references.
+
+use std::{
+    char::{self, DecodeUtf16Error},
+    ffi::{c_char, CStr},
+    fmt,
+    marker::PhantomData,
+    ops::Deref,
+    ptr::NonNull,
+};
+
+/// A borrowed nul-terminated string of unspecified encoding with the same ABI as [`NonNull`].
+///
+/// The [`Debug`] implementation for this type interprets the string as potentially invalid UTF-8.
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct ThinCStr<'a>(NonNull<c_char>, PhantomData<&'a ()>);
+
+impl<'a> ThinCStr<'a> {
+    /// Construct a [`ThinCStr`] from a [`CStr`] ref.
+    pub fn from_cstr(cstr: &'a CStr) -> Self {
+        Self(NonNull::from_ref(cstr).cast(), PhantomData)
+    }
+
+    /// Construct a [`ThinCStr`] from a pointer to a nul-terminated C string.
+    ///
+    /// # Safety
+    ///
+    /// Has the same invariants as [`CStr::from_ptr`].
+    pub unsafe fn from_ptr(ptr: NonNull<c_char>) -> Self {
+        Self(ptr, PhantomData)
+    }
+}
+
+impl<'a> From<&'a CStr> for ThinCStr<'a> {
+    fn from(value: &'a CStr) -> Self {
+        Self::from_cstr(value)
+    }
+}
+
+impl<'a> From<ThinCStr<'a>> for &'a CStr {
+    fn from(value: ThinCStr<'a>) -> Self {
+        // SAFETY: By the invariants of the type
+        unsafe { CStr::from_ptr(value.0.as_ptr()) }
+    }
+}
+
+impl AsRef<CStr> for ThinCStr<'_> {
+    fn as_ref(&self) -> &CStr {
+        (*self).into()
+    }
+}
+
+impl Deref for ThinCStr<'_> {
+    type Target = CStr;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl fmt::Debug for ThinCStr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.deref(), f)
+    }
+}
+
+impl PartialEq for ThinCStr<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.deref() == other.deref()
+    }
+}
+
+impl PartialEq<&CStr> for ThinCStr<'_> {
+    fn eq(&self, other: &&CStr) -> bool {
+        self.deref() == *other
+    }
+}
+
+impl PartialEq<&str> for ThinCStr<'_> {
+    fn eq(&self, other: &&str) -> bool {
+        self.deref().to_bytes() == other.as_bytes()
+    }
+}
+
+impl Eq for ThinCStr<'_> {}
+
+/// A borrowed, nul-terminated wide (u16) string of unspecified encoding with the same ABI as
+/// [`NonNull`].
+///
+/// The [`Debug`] implementation for this type interprets the string as potentially invalid UTF-16.
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct ThinWCStr<'a>(NonNull<u16>, PhantomData<&'a ()>);
+
+impl ThinWCStr<'_> {
+    /// Construct a [`ThinWStr`] from a pointer to a nul-terminated wide C string.
+    ///
+    /// # Safety
+    ///
+    /// Has the same invariants as [`CStr::from_ptr`], except that the element type is a `u16`
+    /// instead of a `c_char`.
+    pub unsafe fn from_ptr(ptr: NonNull<u16>) -> Self {
+        Self(ptr, PhantomData)
+    }
+
+    /// Get a raw pointer to the beginning of this wide C string.
+    pub fn as_ptr(&self) -> *const u16 {
+        self.0.as_ptr()
+    }
+
+    /// Get the length of this wide C string in two-byte units, excluding the nul terminator.
+    pub fn len(&self) -> usize {
+        // SAFETY: By the invariants of the type
+        unsafe {
+            let mut len = 0;
+            while self.0.add(len).read() != 0 {
+                len += 1;
+            }
+            len
+        }
+    }
+
+    /// Check if this C string is empty.
+    pub fn is_empty(&self) -> bool {
+        // SAFETY: By the invariants of the type
+        unsafe { self.0.read() == 0 }
+    }
+
+    /// Converts this C wstring to a u16 slice.
+    ///
+    /// The returned slice will not contain the trailing nul terminator.
+    pub fn to_wchars(&self) -> &[u16] {
+        // SAFETY: By the invariants of the type
+        unsafe { std::slice::from_raw_parts(self.0.as_ptr(), self.len()) }
+    }
+
+    /// Converts this C wstring to a u16 slice, including the nul terminator.
+    pub fn to_wchars_with_nul(&self) -> &[u16] {
+        // SAFETY: By the invariants of the type
+        unsafe { std::slice::from_raw_parts(self.0.as_ptr(), self.len() + 1) }
+    }
+
+    /// Attempt to convert this string to a Rust string, assuming UTF-16 encoding.
+    pub fn to_string(&self) -> Result<String, DecodeUtf16Error> {
+        char::decode_utf16(self.to_wchars().iter().copied()).collect()
+    }
+
+    /// Convert this string to a Rust string, assuming UTF-16 encoding.
+    ///
+    /// Invalid code points are replaced by [`char::REPLACEMENT_CHARACTER`].
+    pub fn to_string_lossy(&self) -> String {
+        char::decode_utf16(self.to_wchars().iter().copied())
+            .map(|c| c.unwrap_or(char::REPLACEMENT_CHARACTER))
+            .collect()
+    }
+}
+
+impl TryFrom<ThinWCStr<'_>> for String {
+    type Error = DecodeUtf16Error;
+
+    fn try_from(value: ThinWCStr<'_>) -> Result<Self, Self::Error> {
+        value.to_string()
+    }
+}
+
+impl AsRef<[u16]> for ThinWCStr<'_> {
+    fn as_ref(&self) -> &[u16] {
+        self.to_wchars()
+    }
+}
+
+impl fmt::Debug for ThinWCStr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use fmt::Write;
+
+        let mut char_iter = char::decode_utf16(self.to_wchars().iter().copied())
+            .map(|c| c.unwrap_or(char::REPLACEMENT_CHARACTER));
+
+        // A Debug representation for a string should be escaped. Instead of
+        // reimplementing the escaping logic, we convert to utf-8 first so the
+        // Debug impl of str can be used.
+        let mut stack_str = [0u8; 128];
+        let mut stack_str_len = 0;
+        let mut heap_str;
+        let lossy_str = loop {
+            if let Some(c) = char_iter.next() {
+                // Possibly not enough space to encode the next character,
+                // fall back to a heap-allocated string.
+                if stack_str_len > stack_str.len() - 4 {
+                    heap_str =
+                        unsafe { String::from_utf8_unchecked(stack_str[..stack_str_len].into()) };
+                    heap_str.write_char(c)?;
+                    for c in char_iter {
+                        heap_str.write_char(c)?;
+                    }
+                    break heap_str.as_str();
+                }
+                stack_str_len += c.encode_utf8(&mut stack_str[stack_str_len..]).len();
+            } else {
+                break unsafe { str::from_utf8_unchecked(&stack_str[..stack_str_len]) };
+            }
+        };
+
+        std::fmt::Debug::fmt(lossy_str, f)
+    }
+}
+
+impl PartialEq for ThinWCStr<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_wchars() == other.to_wchars()
+    }
+}
+
+impl PartialEq<&[u16]> for ThinWCStr<'_> {
+    fn eq(&self, other: &&[u16]) -> bool {
+        self.to_wchars() == *other
+    }
+}
+
+impl Eq for ThinWCStr<'_> {}

--- a/crates/mod-host-types/src/lib.rs
+++ b/crates/mod-host-types/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod alloc;
+pub mod dlrf;
+pub mod ffi;
 pub mod game;
 pub mod string;
 pub mod vector;

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -41,6 +41,7 @@ serde_json.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+memchr.workspace = true
 windows = { workspace = true, features = [
     "Wdk_System_Threading",
     "Win32_Graphics_Gdi",

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -81,7 +81,9 @@ fn enable_loose_params(attach_config: &AttachConfig, mapping: &VfsOverrideMappin
         .iter()
         .any(|file| mapping.virtual_to_disk(file).is_some())
     {
-        ModHost::get_attached().override_game_property("Game.Debug.EnableRegulationFile", false);
+        ModHost::get_attached()
+            .override_game_property("Game.Debug.EnableRegulationFile", "false")
+            .unwrap();
     }
 }
 

--- a/crates/mod-host/src/deferred.rs
+++ b/crates/mod-host/src/deferred.rs
@@ -172,6 +172,8 @@ fn find_prop_hook_addr<'a, P: Pe<'a>>(program: P) -> eyre::Result<Va> {
     Ok(program.rva_to_va(lea_rva)?)
 }
 
+// Use win64 so because it has the most callee-saved registers, which means we don't
+// have to save as much using inline assembly.
 unsafe extern "win64" fn prop_init_hook() {
     if let Some(deferred) = DEFERRED_AFTER_PROP_INIT.lock().unwrap().take() {
         deferred.into_iter().for_each(|f| f());
@@ -184,7 +186,6 @@ unsafe extern "win64" fn prop_init_hook() {
 #[unsafe(naked)]
 unsafe extern "C" fn prop_init_hook_raw() {
     // Simple x64 context save/restore for win64 volatile registers.
-    // We chose win64 as it has a lot of non-volatile registers.
     std::arch::naked_asm!(
         // Move below the sysv64 stack red zone, in case we eventually want to
         // support non-Windows targets (e.g. emulated Bloodborne).
@@ -197,7 +198,7 @@ unsafe extern "C" fn prop_init_hook_raw() {
         "mov rax, rsp",
         "and rsp, -16",
         "push rax",
-        // Push other volatile GRPs.
+        // Push other volatile GPRs.
         "push rcx",
         "push rdx",
         "push r8",
@@ -205,24 +206,25 @@ unsafe extern "C" fn prop_init_hook_raw() {
         "push r10",
         "push r11",
         // Push volatile XMM registers.
+        // Sub an extra 8 bytes to re-align the stack to 16 bytes after the GPR save.
         "sub rsp, 0x68",
-        "movdqa [rsp + 0x00], xmm0",
-        "movdqa [rsp + 0x10], xmm1",
-        "movdqa [rsp + 0x20], xmm2",
-        "movdqa [rsp + 0x30], xmm3",
-        "movdqa [rsp + 0x40], xmm4",
-        "movdqa [rsp + 0x50], xmm5",
+        "movaps [rsp + 0x00], xmm0",
+        "movaps [rsp + 0x10], xmm1",
+        "movaps [rsp + 0x20], xmm2",
+        "movaps [rsp + 0x30], xmm3",
+        "movaps [rsp + 0x40], xmm4",
+        "movaps [rsp + 0x50], xmm5",
         // Allocate shadow stack space and call the hook routine.
         "sub rsp, 0x20",
         "call {hook}",
         "add rsp, 0x20",
         // Restore volatile XMM registers.
-        "movdqa xmm0, [rsp + 0x00]",
-        "movdqa xmm1, [rsp + 0x10]",
-        "movdqa xmm2, [rsp + 0x20]",
-        "movdqa xmm3, [rsp + 0x30]",
-        "movdqa xmm4, [rsp + 0x40]",
-        "movdqa xmm5, [rsp + 0x50]",
+        "movaps xmm0, [rsp + 0x00]",
+        "movaps xmm1, [rsp + 0x10]",
+        "movaps xmm2, [rsp + 0x20]",
+        "movaps xmm3, [rsp + 0x30]",
+        "movaps xmm4, [rsp + 0x40]",
+        "movaps xmm5, [rsp + 0x50]",
         "add rsp, 0x68",
         // Restore volatile GPRs.
         "pop r11",

--- a/crates/mod-host/src/deferred.rs
+++ b/crates/mod-host/src/deferred.rs
@@ -3,24 +3,28 @@ use std::{
     sync::{LazyLock, Mutex, Once},
 };
 
-use eyre::{eyre, OptionExt};
+use eyre::{eyre, Context, ContextCompat, OptionExt};
+use pelite::pe::{Pe, Rva, Va};
+use retour::RawDetour;
 use tracing::{info, instrument, Level, Span};
 use windows::{
     core::{s, w},
     Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW},
 };
 
-use crate::host::ModHost;
+use crate::{executable::Executable, host::ModHost};
 
 pub enum Deferred {
     BeforeMain,
     AfterMain,
+    AfterPropsInit,
 }
 
 type DeferredOnce = Option<Vec<Box<dyn FnOnce() + Send>>>;
 
 static DEFERRED_BEFORE_MAIN: Mutex<DeferredOnce> = Mutex::new(Some(Vec::new()));
 static DEFERRED_AFTER_MAIN: Mutex<DeferredOnce> = Mutex::new(Some(Vec::new()));
+static DEFERRED_AFTER_PROP_INIT: Mutex<DeferredOnce> = Mutex::new(Some(Vec::new()));
 
 /// Defers execution of a closure.
 ///
@@ -44,6 +48,14 @@ where
             HOOKED_STEAM_INIT.as_ref().map_err(|e| eyre!(e))?;
 
             &DEFERRED_AFTER_MAIN
+        }
+        Deferred::AfterPropsInit => {
+            static HOOKED_PROP_INIT: LazyLock<Result<(), eyre::Error>> =
+                LazyLock::new(hook_prop_init);
+
+            HOOKED_PROP_INIT.as_ref().map_err(|e| eyre!(e))?;
+
+            &DEFERRED_AFTER_PROP_INIT
         }
     };
 
@@ -106,4 +118,128 @@ fn schedule_after_arxan() {
             dearxan::disabler::schedule_after_arxan(move |_, _| deferred());
         }
     }
+}
+
+static PROP_INIT_HOOK: Mutex<Option<RawDetour>> = Mutex::new(None);
+static mut PROP_INIT_TRAMPOLINE: *const () = std::ptr::null();
+
+#[instrument]
+fn hook_prop_init() -> eyre::Result<()> {
+    let exe = unsafe { Executable::new() };
+    let hook_addr = find_prop_hook_addr(exe)?;
+
+    let hook = unsafe {
+        RawDetour::new(hook_addr as *const (), prop_init_hook_raw as *const ())
+            .wrap_err("prop init hook creation failed")?
+    };
+
+    unsafe {
+        hook.enable().wrap_err("prop init hook enable failed")?;
+        PROP_INIT_TRAMPOLINE = hook.trampoline();
+    }
+    tracing::debug!("Game property map init hook installed");
+
+    let _ = PROP_INIT_HOOK.lock().unwrap().insert(hook);
+    Ok(())
+}
+
+#[instrument(skip_all)]
+fn find_prop_hook_addr<'a, P: Pe<'a>>(program: P) -> eyre::Result<Va> {
+    const FIRST_PROPERTY: &str = "Game.Debug.NearOnlyDraw";
+
+    let rdata = program
+        .section_headers()
+        .by_name(".rdata")
+        .wrap_err(".rdata section not found")?;
+    let rdata_bytes = program.get_section_bytes(rdata)?;
+
+    let property_wcstr: Vec<_> = FIRST_PROPERTY
+        .encode_utf16()
+        .chain([0])
+        .flat_map(u16::to_le_bytes)
+        .collect();
+
+    let property_string_rva = rdata.VirtualAddress
+        + memchr::memmem::find(rdata_bytes, &property_wcstr)
+            .wrap_err_with(|| format!("Failed to find {FIRST_PROPERTY} in game executable"))?
+            as Rva;
+
+    let lea_rva = *me3_binary_analysis::util::lea_refs(program, property_string_rva)?
+        .first()
+        .wrap_err_with(|| format!("Failed to find LEA referencing {FIRST_PROPERTY}"))?;
+
+    tracing::debug!("{FIRST_PROPERTY} lea RVA: {lea_rva:x}");
+    Ok(program.rva_to_va(lea_rva)?)
+}
+
+unsafe extern "win64" fn prop_init_hook() {
+    if let Some(deferred) = DEFERRED_AFTER_PROP_INIT.lock().unwrap().take() {
+        deferred.into_iter().for_each(|f| f());
+    }
+    if let Some(hook) = PROP_INIT_HOOK.lock().unwrap().as_ref() {
+        let _ = unsafe { hook.disable() };
+    }
+}
+
+#[unsafe(naked)]
+unsafe extern "C" fn prop_init_hook_raw() {
+    // Simple x64 context save/restore for win64 volatile registers.
+    // We chose win64 as it has a lot of non-volatile registers.
+    std::arch::naked_asm!(
+        // Move below the sysv64 stack red zone, in case we eventually want to
+        // support non-Windows targets (e.g. emulated Bloodborne).
+        // Do this with a LEA instead of ADD/SUB so EFLAGS is unchanged.
+        "lea rsp, [rsp - 0x80]",
+        // First save EFLAGS, RSP and align the stack.
+        // To branchlessly align the stack, we need a scratch register. Use RAX.
+        "pushfq",
+        "push rax",
+        "mov rax, rsp",
+        "and rsp, -16",
+        "push rax",
+        // Push other volatile GRPs.
+        "push rcx",
+        "push rdx",
+        "push r8",
+        "push r9",
+        "push r10",
+        "push r11",
+        // Push volatile XMM registers.
+        "sub rsp, 0x68",
+        "movdqa [rsp + 0x00], xmm0",
+        "movdqa [rsp + 0x10], xmm1",
+        "movdqa [rsp + 0x20], xmm2",
+        "movdqa [rsp + 0x30], xmm3",
+        "movdqa [rsp + 0x40], xmm4",
+        "movdqa [rsp + 0x50], xmm5",
+        // Allocate shadow stack space and call the hook routine.
+        "sub rsp, 0x20",
+        "call {hook}",
+        "add rsp, 0x20",
+        // Restore volatile XMM registers.
+        "movdqa xmm0, [rsp + 0x00]",
+        "movdqa xmm1, [rsp + 0x10]",
+        "movdqa xmm2, [rsp + 0x20]",
+        "movdqa xmm3, [rsp + 0x30]",
+        "movdqa xmm4, [rsp + 0x40]",
+        "movdqa xmm5, [rsp + 0x50]",
+        "add rsp, 0x68",
+        // Restore volatile GPRs.
+        "pop r11",
+        "pop r10",
+        "pop r9",
+        "pop r8",
+        "pop rdx",
+        "pop rcx",
+        // Restore original RSP, RAX and EFLAGS.
+        "pop rsp",
+        "pop rax",
+        "popfq",
+        // Move RSP back to the top of the sysv64 stack red zone.
+        "lea rsp, [rsp + 0x80]",
+        // Jump back to the original address
+        "jmp qword ptr [rip+{trampoline}]",
+        hook = sym prop_init_hook,
+        trampoline = sym PROP_INIT_TRAMPOLINE
+    );
 }

--- a/crates/mod-host/src/host.rs
+++ b/crates/mod-host/src/host.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use closure_ffi::traits::FnPtr;
+use eyre::Context;
 use libloading::{Library, Symbol};
 use me3_launcher_attach_protocol::AttachConfig;
 use me3_mod_protocol::{native::NativeInitializerCondition, Game, ModProfile};
@@ -33,7 +34,7 @@ pub struct ModHost {
     hooks: Mutex<Vec<Arc<UntypedDetour>>>,
     native_modules: Mutex<Vec<Library>>,
     profiles: Vec<ModProfile>,
-    property_overrides: Mutex<HashMap<Vec<u16>, bool>>,
+    property_overrides: Mutex<HashMap<CString, CString>>,
     pub disable_arxan: bool,
 }
 
@@ -127,10 +128,19 @@ impl ModHost {
         HookInstaller::new(target).on_install(|hook| self.hooks.lock().unwrap().push(hook))
     }
 
-    pub fn override_game_property<S: AsRef<str>>(&self, property: S, state: bool) {
+    pub fn override_game_property(
+        &self,
+        property: impl AsRef<str>,
+        value: impl AsRef<str>,
+    ) -> eyre::Result<()> {
+        let property = CString::new(property.as_ref()).wrap_err("Nul byte in property key")?;
+        let value = CString::new(value.as_ref()).wrap_err("Nul byte in property value")?;
+
         self.property_overrides
             .lock()
-            .unwrap()
-            .insert(property.as_ref().encode_utf16().collect(), state);
+            .expect("poisoned")
+            .insert(property, value);
+
+        Ok(())
     }
 }

--- a/crates/mod-host/src/host/game_properties.rs
+++ b/crates/mod-host/src/host/game_properties.rs
@@ -1,127 +1,66 @@
-use std::{collections::HashMap, mem, slice, sync::Arc};
+use std::ffi::c_char;
 
-use eyre::OptionExt;
-use me3_launcher_attach_protocol::AttachConfig;
-use me3_mod_host_types::string::DlUtf16String;
+use eyre::ContextCompat;
+use me3_mod_host_types::dlrf::RuntimeClassEntry;
 use me3_mod_protocol::Game;
-use pelite::pe::Pe;
-use rdvec::Vec;
-use regex::bytes::Regex;
-use tracing::{error, instrument, Span};
-use windows::core::PCWSTR;
+use rdvec::Vec as _;
+use tracing::{instrument, Span};
 
 use crate::{
     deferred::{defer_init, Deferred},
-    executable::Executable,
     host::ModHost,
 };
 
-type GetBoolProperty = unsafe extern "C" fn(usize, *const (), bool) -> bool;
-
 pub fn start_offline() {
-    ModHost::get_attached().override_game_property("Menu.IsEnableOnlineMode", false);
+    ModHost::get_attached()
+        .override_game_property("Menu.IsEnableOnlineMode", "false")
+        .unwrap();
 }
 
 #[instrument(skip_all)]
 pub fn attach_override(
-    attach_config: Arc<AttachConfig>,
-    exe: Executable,
+    game: Game,
+    runtime_classes: &[RuntimeClassEntry<'_>],
 ) -> Result<(), eyre::Error> {
-    let game = attach_config.game;
-
-    let do_override = move || {
-        let get_bool_property = bool_property_getter(attach_config, exe)?;
-
-        ModHost::get_attached()
-            .hook(get_bool_property)
-            .with_closure(move |p1, name, default, trampoline| unsafe {
-                if name.is_null() {
-                    return false;
-                }
-
-                let property = if game >= Game::ArmoredCore6 {
-                    let name = PCWSTR::from_raw(name as *const u16);
-                    slice::from_raw_parts(name.as_ptr(), name.len())
-                } else {
-                    let name = &*(name as *const DlUtf16String);
-                    name.get().unwrap().as_slice()
-                };
-
-                ModHost::get_attached()
-                    .property_overrides
-                    .lock()
-                    .unwrap()
-                    .get(property)
-                    .copied()
-                    .unwrap_or_else(|| trampoline(p1, name, default))
-            })
-            .install()?;
-
-        eyre::Ok(())
+    let capi_name = if game < Game::EldenRing {
+        "SprjAutoControlAPI"
+    } else {
+        "CSAutoControlAPI"
     };
 
-    // Some games (Dark Souls 3) might employ Arxan encryption
-    // that is removed after running the Arxan entrypoint.
-    defer_init(Span::current(), Deferred::BeforeMain, move || {
-        if let Err(e) = do_override() {
-            error!("error" = %e, "failed to hook property getter");
+    let capi_class = runtime_classes
+        .iter()
+        .find(|entry| entry.class.name == capi_name)
+        .wrap_err_with(|| format!("failed to find runtime class for {capi_name}"))?
+        .class;
+
+    let set_game_prop_resolver = capi_class
+        .methods
+        .iter()
+        .find(|m| m.name == "SetGameProperty")
+        .wrap_err("SetGameProperty method not found")?
+        .resolver;
+
+    let set_game_prop_addr = set_game_prop_resolver
+        .invokers
+        .first()
+        .wrap_err("SetGameProperty has no method invokers")?
+        .addr;
+
+    tracing::debug!(?set_game_prop_addr);
+
+    let set_game_prop: unsafe extern "C" fn(*const c_char, *const c_char) =
+        unsafe { std::mem::transmute(set_game_prop_addr) };
+
+    defer_init(Span::current(), Deferred::AfterPropsInit, move || {
+        let overrides = ModHost::get_attached()
+            .property_overrides
+            .lock()
+            .expect("poisoned");
+
+        tracing::debug!("applying game property overrides: {overrides:#?}");
+        for (property, value) in overrides.iter() {
+            unsafe { set_game_prop(property.as_ptr(), value.as_ptr()) }
         }
-    })?;
-
-    Ok(())
-}
-
-fn bool_property_getter(
-    attach_config: Arc<AttachConfig>,
-    exe: Executable,
-) -> Result<GetBoolProperty, eyre::Error> {
-    // Matches callsites for the boolean DLSystemProperty getter.
-    //
-    // In Dark Souls 3, Sekiro and ER, the getter takes in a reference to a DLString,
-    // in later games, it was changed to a nul terminated UTF-16 string pointer.
-    //
-    // The patterns match loading the pointer to the `std::map` containing the property names
-    // and their values loaded in RCX, the queried property name in RDX and true/false in R8B
-    // as the default value in the case of the property missing from the map.
-    let function_call_re_str = match attach_config.game {
-        Game::DarkSouls3 => {
-            r"(?s-u)(?:\x48\x8d\x54\x24\x30\x48\x8b\x0d.{4}\xe8(.{4})\x88\x05.{4}\x48\x83\x7c\x24\x48\x08\x72.)|(?:\x48\x8d\x54\x24\x30\x48\x8b\x0d.{4}\xe8(.{4})\x0f\xb6\xd8\x48\x83\x7c\x24\x48\x08\x72.)"
-        }
-        Game::Sekiro | Game::EldenRing => {
-            r"(?s-u)(?:\x48\x8d\x54\x24\x30\x48\x8b\x0d.{4}\xe8(.{4})\x88\x05.{4}\x48\x83\x7c\x24\x50\x08\x72.)|(?:\x48\x8d\x54\x24\x30\x48\x8b\x0d.{4}\xe8(.{4})\x0f\xb6\xd8\x48\x83\x7c\x24\x50\x08\x72.)"
-        }
-        Game::ArmoredCore6 | Game::Nightreign => {
-            r"(?s-u)(?:(?:\x45\x33\xc0)|(?:\x41\xb0\x01))\x48\x8d\x15.{4}\x48\x8b\x0d.{4}\xe8(.{4})"
-        }
-    };
-
-    let function_call_re = Regex::new(function_call_re_str).unwrap();
-
-    let text = exe.get_section_bytes(
-        exe.section_headers()
-            .by_name(".text")
-            .ok_or_eyre(".text section is missing")?,
-    )?;
-
-    // The above patterns return a lot of matches, filter by the most common one
-    // to definitively pick the right match.
-    function_call_re
-        .captures_iter(text)
-        .map(|c| {
-            let [call_disp32] = c.extract().1;
-            let call_bytes = <[u8; 4]>::try_from(call_disp32).unwrap();
-
-            call_disp32
-                .as_ptr_range()
-                .end
-                .wrapping_byte_offset(i32::from_le_bytes(call_bytes) as _)
-        })
-        .fold(HashMap::<_, usize>::new(), |mut map, ptr| {
-            *map.entry(ptr).or_default() += 1;
-            map
-        })
-        .into_iter()
-        .max_by_key(|(_, count)| *count)
-        .map(|(ptr, _)| unsafe { mem::transmute::<_, GetBoolProperty>(ptr) })
-        .ok_or_eyre("pattern returned no matches")
+    })
 }

--- a/crates/mod-host/src/lib.rs
+++ b/crates/mod-host/src/lib.rs
@@ -6,7 +6,7 @@
 use std::sync::{Arc, Mutex, OnceLock};
 
 use eyre::OptionExt;
-use me3_binary_analysis::{fd4_step::Fd4StepTables, rtti};
+use me3_binary_analysis::{dlrf, fd4_step::Fd4StepTables, rtti};
 use me3_env::TelemetryVars;
 use me3_ipc::{
     bridge::BridgeToParent,
@@ -15,6 +15,7 @@ use me3_ipc::{
 };
 use me3_launcher_attach_protocol::{AttachConfig, AttachRequest, AttachResult, Attachment};
 use me3_mod_host_assets::mapping::VfsOverrideMapping;
+use me3_mod_host_types::dlrf::RuntimeClassEntry;
 use me3_telemetry::TelemetryConfig;
 use tracing::{error, info, instrument, warn, Span};
 use windows::Win32::{
@@ -106,12 +107,6 @@ fn on_attach(request: AttachRequest) -> AttachResult {
 
         skip_logos::attach_override(attach_config.clone(), exe)?;
 
-        game_properties::attach_override(attach_config.clone(), exe)?;
-
-        if !attach_config.start_online {
-            game_properties::start_offline();
-        }
-
         let mut override_mapping = VfsOverrideMapping::new()?;
         override_mapping.scan_directories(attach_config.packages.iter())?;
         savefile::attach_override(&attach_config, &mut override_mapping)?;
@@ -174,6 +169,12 @@ fn after_game_main<R: FnOnce() -> Result<(), eyre::Error>>(
 
     let class_map = Arc::new(rtti::classes(exe)?);
     let step_tables = Fd4StepTables::from_initialized_data(exe)?;
+    let runtime_classes = unsafe { RuntimeClassEntry::from_analysis(dlrf::runtime_classes(exe)?) };
+
+    game_properties::attach_override(attach_config.game, runtime_classes)?;
+    if !attach_config.start_online {
+        game_properties::start_offline();
+    }
 
     if attach_config.mem_patch {
         alloc_hooks::hook_heap_allocators(&attach_config, exe, &class_map)?;


### PR DESCRIPTION
Reworks the game property override logic to fetch `CSControlAPI::SetGameProperty` from DLRF data and use that instead of a getter hook. This allows supporting overrides for all property types, so that this functionality can be eventually exposed to users.

As part of this, adds DLRF type definitions and a simple analysis for finding the `DLRuntimeClass` registry.

Unfortunately, the game property map is not initialized during our `AfterMain` deferred execution step, so I had to add a third `AfterPropsInit` step that runs right after the map is constructed. This is done without AOBs or RTTI by:
- Searching for LEA xrefs to `Game.Debug.NearOnlyDraw`. This is the first property queried after constructing the map by all supported games.
- Inline hooking the LEA instruction using a `RawDetour` and a handrolled register context save/restore.

The total analysis time for this new approach (finding runtime classes and hook point) for ER is just under 5ms on my machine.

Tested successfully on all supported games.