### PR TITLE
fix(host): use correct signature for Fd4StepFunction

### DIFF
--- a/crates/binary-analysis/src/fd4_step.rs
+++ b/crates/binary-analysis/src/fd4_step.rs
@@ -15,7 +15,14 @@ use thiserror::Error;
 
 use crate::pe::sections;
 
-pub type Fd4StepFunction = unsafe extern "C" fn(this: NonNull<()>);
+pub type Fd4StepFunction = unsafe extern "C" fn(this: NonNull<()>, time: NonNull<FD4Time>);
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct FD4Time {
+    pub vtable: usize,
+    pub time: f32,
+}
 
 #[derive(Debug, Error)]
 pub enum Fd4StepError {

--- a/crates/mod-host/src/asset_hooks.rs
+++ b/crates/mod-host/src/asset_hooks.rs
@@ -103,13 +103,13 @@ fn hook_file_init(
     ModHost::get_attached()
         .hook(init_fn)
         .with_span(info_span!("hook"))
-        .with_closure(move |p1, trampoline| {
+        .with_closure(move |p1, p2, trampoline| {
             let result = hook_device_manager(exe, mapping.clone())
                 .and_then(|_| hook_mount_ebl(attach_config.clone(), exe))
                 .inspect_err(|e| error!("error" = &**e, "failed apply pre-hooks"));
 
             unsafe {
-                trampoline(p1);
+                trampoline(p1, p2);
             }
 
             if result.is_ok()

--- a/crates/mod-host/src/savefile.rs
+++ b/crates/mod-host/src/savefile.rs
@@ -99,8 +99,8 @@ fn oversized_regulation_fix_after_er(
     // Intercept and free the raw regulation to prevent writing it to the savefile.
     ModHost::get_attached()
         .hook(apply_fn)
-        .with_closure(move |p1, trampoline| unsafe {
-            trampoline(p1);
+        .with_closure(move |p1, p2, trampoline| unsafe {
+            trampoline(p1, p2);
 
             let regulation_manager = from_singleton::address_of::<CSRegulationManager>()
                 .unwrap()


### PR DESCRIPTION
The incorrect signature led to the second parameter potentially being cloberred by an arbitrary value from a hook routine, leading to crashes or other undefined behavior.