### PR TITLE
docs: Disable Google Analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,34 +76,6 @@ extra:
     - name: Polski
       link: /pl/
       lang: pl
-  analytics:
-    provider: google
-    property: G-FMPH9RP5EH
-    feedback:
-      title: Was this page helpful?
-      ratings:
-        - icon: material/emoticon-happy-outline
-          name: This page was helpful
-          data: 1
-          note: >-
-            Thanks for your feedback!
-        - icon: material/emoticon-sad-outline
-          name: This page could be improved
-          data: 0
-          note: >-
-            Thanks for your feedback!
-
-  consent:
-    title: Cookie consent
-    actions:
-      - accept
-      - reject
-      - manage
-    description: >-
-      We use cookies to recognize your repeated visits and preferences, as well
-      as to measure the effectiveness of our documentation and whether users
-      find what they're searching for. With your consent, you're helping us to
-      make our documentation better.
 
 nav:
   - index.md


### PR DESCRIPTION
The only valuable information we get from here is the regions our users come from (for localization and internationalization) and the operating system versions for support, the rest is being siphoned to Google for no good reason.

For the former we can rely on network metrics instead, and for the latter we can use the Steam survey.