### PR TITLE
fix(host): Improve mem_patch stability

### DIFF
--- a/.github/actions/setup-windows-toolchain/action.yml
+++ b/.github/actions/setup-windows-toolchain/action.yml
@@ -3,11 +3,22 @@ description: "Install and set up the x86_64-pc-windows-msvc Rust toolchain"
 runs:
   using: 'composite'
   steps:
+    - name: Run apt-get update
+      shell: bash
+      run: sudo apt-get update
+
+    - name: Install NSIS and wkhtmltopdf
+      shell: bash
+      run: sudo apt install --install-recommends nsis wkhtmltopdf
+
     - name: Install LLVM
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt install --install-recommends lld clang-tools llvm wkhtmltopdf nsis
+        sudo apt install --install-recommends llvm-20 clang-20 lld-20
+
+        for tool in llvm-ar llvm-config llvm-cov llvm-lib llvm-link llvm-rc clang-cl lld lld-link; do
+            sudo update-alternatives --install /usr/bin/$tool $tool /usr/bin/$tool-20 200
+        done
 
     - name: Cache MSVC SDK
       id: cache-xwin
@@ -26,14 +37,18 @@ runs:
     - name: Generate x86_64-pc-windows-msvc configuration
       shell: bash
       run: |
+        for tool in llvm-ar llvm-config llvm-cov llvm-lib llvm-link llvm-rc clang-cl lld lld-link; do
+            sudo update-alternatives --auto $tool
+        done
+
         {
             CL_FLAGS="-Wno-unused-command-line-argument -fuse-ld=lld-link  /imsvc${{ github.workspace }}/xwin/crt/include  /imsvc${{ github.workspace }}/xwin/sdk/include/ucrt  /imsvc${{ github.workspace }}/xwin/sdk/include/um /imsvc${{ github.workspace }}/xwin/sdk/include/shared"
 
             echo "AR_x86_64_pc_windows_msvc=llvm-lib"
             echo "CFLAGS_x86_64_pc_windows_msvc=$CL_FLAGS"
             echo "CXXFLAGS_x86_64_pc_windows_msvc=$CL_FLAGS /EHsc"
-            echo "CC_x86_64_pc_windows_msvc=clang-cl-18"
-            echo "CXX_x86_64_pc_windows_msvc=clang-cl-18"
+            echo "CC_x86_64_pc_windows_msvc=clang-cl"
+            echo "CXX_x86_64_pc_windows_msvc=clang-cl"
         } >>"$GITHUB_ENV"
 
         cat >~/.cargo/config.toml <<EOF

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,13 +1599,12 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
  "cty",
- "libc",
 ]
 
 [[package]]

--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -30,7 +30,8 @@ use tracing::{error, info};
 use crate::{
     commands::{
         launch::{
-            named_pipe::NamedPipe, strategy::compat_tool::CompatTools, strategy::LaunchStrategy,
+            named_pipe::NamedPipe,
+            strategy::{compat_tool::CompatTools, LaunchStrategy},
         },
         profile::ProfileOptions,
     },
@@ -311,6 +312,7 @@ impl LaunchArgs {
             start_online: profile_options.start_online.unwrap_or(false),
             disable_arxan: profile_options.disable_arxan.unwrap_or(false),
             mem_patch: !profile_options.no_mem_patch.unwrap_or(false),
+            mem_patch_heap_size: profile_options.heap_size,
             skip_steam_init: opts.skip_steam_init.unwrap_or(false),
             property_overrides,
         })
@@ -601,6 +603,7 @@ mod tests {
                 start_online: None,
                 disable_arxan: None,
                 no_mem_patch: None,
+                heap_size: None,
                 debug_properties: Default::default()
             },
         );
@@ -641,6 +644,7 @@ mod tests {
                 start_online: Some(true),
                 disable_arxan: Some(true),
                 no_mem_patch: Some(true),
+                heap_size: None,
                 debug_properties: Default::default()
             },
         );
@@ -681,6 +685,7 @@ mod tests {
                 start_online: Some(false),
                 disable_arxan: Some(false),
                 no_mem_patch: Some(false),
+                heap_size: None,
                 debug_properties: Default::default()
             },
         );
@@ -721,6 +726,7 @@ mod tests {
                 start_online: Some(true),
                 disable_arxan: Some(true),
                 no_mem_patch: Some(true),
+                heap_size: None,
                 debug_properties: Default::default()
             },
         );

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -89,6 +89,13 @@ pub struct ProfileOptions {
     #[clap(long("no-mem-patch"), default_missing_value = "true", num_args=0..=1)]
     pub no_mem_patch: Option<bool>,
 
+    /// Override the default heap allocation size (in MB).
+    ///
+    /// A sensible default between 6144 and 12288 is already used for games that support
+    /// `mem_patch`. Does nothing in combination with `--no-mem-patch`.
+    #[clap(long("heap-size"))]
+    pub heap_size: Option<u32>,
+
     /// Debug game property override [repeatable option]
     ///
     /// Override a debug game property, e.g. `--debug-prop Game.Debug.NearOnlyDraw=true`. Do not
@@ -121,6 +128,7 @@ impl ProfileOptions {
                 (a, b) => a.or(b),
             },
             no_mem_patch: other.no_mem_patch.or(self.no_mem_patch),
+            heap_size: self.heap_size.max(other.heap_size),
             debug_properties: self
                 .debug_properties
                 .into_iter()

--- a/crates/cli/src/db/profile.rs
+++ b/crates/cli/src/db/profile.rs
@@ -89,7 +89,8 @@ impl Profile {
         ProfileOptions {
             start_online: self.profile.start_online(),
             disable_arxan: self.profile.disable_arxan(),
-            no_mem_patch: self.profile.patch_mem().map(|b| !b),
+            no_mem_patch: self.profile.mem_patch().map(|b| !b),
+            heap_size: self.profile.mem_patch_heap_size(),
             debug_properties: self.profile.debug_properties(),
         }
     }

--- a/crates/launcher-attach-protocol/src/lib.rs
+++ b/crates/launcher-attach-protocol/src/lib.rs
@@ -63,6 +63,10 @@ pub struct AttachConfig {
     /// Patch memory limits for supported games.
     pub mem_patch: bool,
 
+    /// Override how many megabytes of memory the supported game should allocate
+    /// (with `mem_patch = true`).
+    pub mem_patch_heap_size: Option<u32>,
+
     /// Should we avoid checking if Steam is running as part of pre-launch checks?
     pub skip_steam_init: bool,
 

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -23,7 +23,7 @@ dearxan = "0.5.2"
 eyre = { workspace = true, default-features = false, features = ["track-caller"] }
 from-singleton.workspace = true
 libloading = "0.9.0"
-libmimalloc-sys = { version = "0.1.44", features = ["v3", "extended"] }
+libmimalloc-sys = { version = "0.1.49", features = ["extended", "arena"] }
 me3-binary-analysis.workspace = true
 me3-env.workspace = true
 me3-ipc.workspace = true

--- a/crates/mod-host/src/alloc_hooks.rs
+++ b/crates/mod-host/src/alloc_hooks.rs
@@ -74,6 +74,10 @@ pub fn hook_system_allocator(
         return Ok(());
     }
 
+    if let Some(size) = attach_config.mem_patch_heap_size {
+        mimalloc::set_heap_size(size);
+    }
+
     let mut result = None;
 
     SYSTEM_ALLOC_IS_HOOKED.get_or_init(|| {

--- a/crates/mod-host/src/alloc_hooks/mimalloc.rs
+++ b/crates/mod-host/src/alloc_hooks/mimalloc.rs
@@ -1,7 +1,14 @@
-use std::{mem::ManuallyDrop, ptr::NonNull};
+use std::{mem::ManuallyDrop, ptr::NonNull, sync::LazyLock};
 
-use libmimalloc_sys::{mi_free, mi_malloc_aligned, mi_realloc_aligned, mi_usable_size};
-use me3_mod_host_types::alloc::{DlAllocator, DlAllocatorVtable, DlHeapDirection};
+use libmimalloc_sys::{
+    mi_arena_id_t, mi_free, mi_heap_malloc_aligned, mi_heap_new_in_arena, mi_heap_realloc_aligned,
+    mi_heap_t, mi_option_set, mi_reserve_os_memory_ex, mi_usable_size,
+};
+use me3_mod_host_types::{
+    alloc::{DlAllocator, DlAllocatorVtable, DlHeapDirection},
+    game::GAME,
+};
+use me3_mod_protocol::Game;
 
 pub static MIMALLOC_DLALLOC: DlAllocator = DlAllocator {
     vtable: NonNull::from_ref(&MIMALLOC_DLALLOC_VTABLE),
@@ -34,6 +41,39 @@ const MIMALLOC_DLALLOC_VTABLE: DlAllocatorVtable = DlAllocatorVtable {
     unlock,
     block_of,
 };
+
+/// A contiguous, pre-committed heap used in place of mimalloc's default heap to reduce
+/// crashes caused by bad memory accesses.
+static mut MI_HEAP: LazyLock<*mut mi_heap_t> = LazyLock::new(|| unsafe {
+    // Disable decommitting purged pages to reduce the likelihood of crashing
+    // because of use-after-free and OOB access bugs. This is especially important in Sekiro,
+    // which consistently causes OOB reads in a certain `GXFlverMaterial` function (these reads
+    // may cross page boundaries and segfault on a decommitted page when this option is "1").
+    let mi_option_purge_decommits = 5;
+    mi_option_set(mi_option_purge_decommits, 0);
+
+    // Assuming an overcommit system, numbers are based on how much memory the games already
+    // commit, manual testing and expectations for upper bounds on memory usage.
+    // Since `mi_option_disallow_os_alloc` is not set mimalloc may reserve even more memory
+    // outside of this arena as it needs.
+    let size_mb = match *GAME {
+        Game::DarkSouls3 => 6 * 1024,
+        Game::Sekiro => 6 * 1024,
+        Game::EldenRing => 12 * 1024,
+        _ => unimplemented!("this game does not support mem_patch?"),
+    };
+
+    let size_bytes = size_mb * 1024 * 1024;
+    let mut arena_id = mi_arena_id_t::default();
+
+    let res = mi_reserve_os_memory_ex(size_bytes, true, true, true, &mut arena_id);
+
+    if res != 0 {
+        panic!("mimalloc failed to reserve and commit OS memory");
+    }
+
+    mi_heap_new_in_arena(arena_id)
+});
 
 unsafe extern "C" fn dtor(_: NonNull<ManuallyDrop<DlAllocator>>) {}
 
@@ -80,27 +120,27 @@ unsafe extern "C" fn block_size(_: NonNull<DlAllocator>, block: *mut u8) -> usiz
     }
 }
 
-#[inline]
-unsafe extern "C" fn allocate(_: NonNull<DlAllocator>, size: usize) -> *mut u8 {
-    unsafe { mi_malloc_aligned(size.next_multiple_of(16), 16) as _ }
+unsafe extern "C" fn allocate(this: NonNull<DlAllocator>, size: usize) -> *mut u8 {
+    unsafe { allocate_aligned(this, size, 16) }
 }
 
-#[inline]
 unsafe extern "C" fn allocate_aligned(
     _: NonNull<DlAllocator>,
     size: usize,
     alignment: usize,
 ) -> *mut u8 {
     let alignment = alignment.max(16);
-    unsafe { mi_malloc_aligned(size.next_multiple_of(alignment), alignment) as _ }
+    unsafe { mi_heap_malloc_aligned(*MI_HEAP, size.next_multiple_of(alignment), alignment) as _ }
 }
 
-#[inline]
-unsafe extern "C" fn reallocate(_: NonNull<DlAllocator>, old: *mut u8, new_size: usize) -> *mut u8 {
-    unsafe { mi_realloc_aligned(old as _, new_size.next_multiple_of(16), 16) as _ }
+unsafe extern "C" fn reallocate(
+    this: NonNull<DlAllocator>,
+    old: *mut u8,
+    new_size: usize,
+) -> *mut u8 {
+    unsafe { reallocate_aligned(this, old, new_size, 16) }
 }
 
-#[inline]
 unsafe extern "C" fn reallocate_aligned(
     _: NonNull<DlAllocator>,
     old: *mut u8,
@@ -108,10 +148,16 @@ unsafe extern "C" fn reallocate_aligned(
     alignment: usize,
 ) -> *mut u8 {
     let alignment = alignment.max(16);
-    unsafe { mi_realloc_aligned(old as _, new_size.next_multiple_of(alignment), alignment) as _ }
+    unsafe {
+        mi_heap_realloc_aligned(
+            *MI_HEAP,
+            old as _,
+            new_size.next_multiple_of(alignment),
+            alignment,
+        ) as _
+    }
 }
 
-#[inline]
 unsafe extern "C" fn free(_: NonNull<DlAllocator>, ptr: *mut u8) {
     unsafe {
         mi_free(ptr as _);

--- a/crates/mod-host/src/alloc_hooks/mimalloc.rs
+++ b/crates/mod-host/src/alloc_hooks/mimalloc.rs
@@ -1,4 +1,11 @@
-use std::{mem::ManuallyDrop, ptr::NonNull, sync::LazyLock};
+use std::{
+    mem::ManuallyDrop,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        LazyLock,
+    },
+};
 
 use libmimalloc_sys::{
     mi_arena_id_t, mi_free, mi_heap_malloc_aligned, mi_heap_new_in_arena, mi_heap_realloc_aligned,
@@ -13,6 +20,12 @@ use me3_mod_protocol::Game;
 pub static MIMALLOC_DLALLOC: DlAllocator = DlAllocator {
     vtable: NonNull::from_ref(&MIMALLOC_DLALLOC_VTABLE),
 };
+
+static HEAP_SIZE_MB: AtomicU32 = AtomicU32::new(0);
+
+pub fn set_heap_size(new_size_mb: u32) {
+    HEAP_SIZE_MB.store(new_size_mb, Ordering::Release);
+}
 
 const MIMALLOC_DLALLOC_VTABLE: DlAllocatorVtable = DlAllocatorVtable {
     dtor,
@@ -56,14 +69,17 @@ static mut MI_HEAP: LazyLock<*mut mi_heap_t> = LazyLock::new(|| unsafe {
     // commit, manual testing and expectations for upper bounds on memory usage.
     // Since `mi_option_disallow_os_alloc` is not set mimalloc may reserve even more memory
     // outside of this arena as it needs.
-    let size_mb = match *GAME {
-        Game::DarkSouls3 => 6 * 1024,
-        Game::Sekiro => 6 * 1024,
-        Game::EldenRing => 12 * 1024,
-        _ => unimplemented!("this game does not support mem_patch?"),
-    };
+    let mut size_mb = HEAP_SIZE_MB.load(Ordering::Acquire);
+    if size_mb == 0 {
+        size_mb = match *GAME {
+            Game::DarkSouls3 => 6 * 1024,
+            Game::Sekiro => 6 * 1024,
+            Game::EldenRing => 12 * 1024,
+            _ => unimplemented!("this game does not support mem_patch?"),
+        };
+    }
 
-    let size_bytes = size_mb * 1024 * 1024;
+    let size_bytes = size_mb as usize * 1024 * 1024;
     let mut arena_id = mi_arena_id_t::default();
 
     let res = mi_reserve_os_memory_ex(size_bytes, true, true, true, &mut arena_id);

--- a/crates/mod-protocol/src/lib.rs
+++ b/crates/mod-protocol/src/lib.rs
@@ -112,9 +112,15 @@ impl ModProfile {
         }
     }
 
-    pub fn patch_mem(&self) -> Option<bool> {
+    pub fn mem_patch(&self) -> Option<bool> {
         match self {
-            ModProfile::V1(v1) => v1.patch_mem,
+            ModProfile::V1(v1) => v1.mem_patch,
+        }
+    }
+
+    pub fn mem_patch_heap_size(&self) -> Option<u32> {
+        match self {
+            ModProfile::V1(v1) => v1.mem_patch_heap_size,
         }
     }
 
@@ -161,7 +167,13 @@ pub struct ModProfileV1 {
 
     /// Patch memory limits for supported games to improve mod stability.
     #[serde(default)]
-    patch_mem: Option<bool>,
+    #[serde(alias = "patch_mem")]
+    mem_patch: Option<bool>,
+
+    /// Override how many megabytes of memory the supported game should allocate
+    /// (with `mem_patch = true`).
+    #[serde(default)]
+    mem_patch_heap_size: Option<u32>,
 
     /// Debug game property overrides.
     #[serde(default)]

--- a/crates/mod-protocol/test-data/basic_config.me3.toml.expected
+++ b/crates/mod-protocol/test-data/basic_config.me3.toml.expected
@@ -31,7 +31,8 @@ V1(
         savefile: None,
         start_online: None,
         disable_arxan: None,
-        patch_mem: None,
+        mem_patch: None,
+        mem_patch_heap_size: None,
         debug_properties: DebugProperties {
             props: {},
         },

--- a/crates/mod-protocol/test-data/debug_properties.me3.expected
+++ b/crates/mod-protocol/test-data/debug_properties.me3.expected
@@ -18,7 +18,8 @@ V1(
         savefile: None,
         start_online: None,
         disable_arxan: None,
-        patch_mem: None,
+        mem_patch: None,
+        mem_patch_heap_size: None,
         debug_properties: DebugProperties {
             props: {
                 "prop1.foo": Uint(

--- a/crates/mod-protocol/test-data/plural_packages.me3.expected
+++ b/crates/mod-protocol/test-data/plural_packages.me3.expected
@@ -18,7 +18,8 @@ V1(
         savefile: None,
         start_online: None,
         disable_arxan: None,
-        patch_mem: None,
+        mem_patch: None,
+        mem_patch_heap_size: None,
         debug_properties: DebugProperties {
             props: {},
         },

--- a/crates/mod-protocol/test-data/singular_package.me3.expected
+++ b/crates/mod-protocol/test-data/singular_package.me3.expected
@@ -18,7 +18,8 @@ V1(
         savefile: None,
         start_online: None,
         disable_arxan: None,
-        patch_mem: None,
+        mem_patch: None,
+        mem_patch_heap_size: None,
         debug_properties: DebugProperties {
             props: {},
         },

--- a/schemas/mod-profile.json
+++ b/schemas/mod-profile.json
@@ -316,12 +316,22 @@
           ],
           "default": null
         },
-        "patch_mem": {
+        "mem_patch": {
           "description": "Patch memory limits for supported games to improve mod stability.",
           "type": [
             "boolean",
             "null"
           ],
+          "default": null
+        },
+        "mem_patch_heap_size": {
+          "description": "Override how many megabytes of memory the supported game should allocate\n(with `mem_patch = true`).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0,
           "default": null
         },
         "debug_properties": {

--- a/schemas/mod-profile.md
+++ b/schemas/mod-profile.md
@@ -98,5 +98,7 @@ before the DVDBND. Default: `[]`.
   - **`savefile`** *(['string', 'null'])*: Name of an alternative savefile to use (in the default savefile directory). Default: `null`.
   - **`start_online`** *(['boolean', 'null'])*: Starts the game with multiplayer server connectivity enabled. Default: `null`.
   - **`disable_arxan`** *(['boolean', 'null'])*: Try to neutralize Arxan GuardIT code protection to improve mod stability. Default: `null`.
-  - **`patch_mem`** *(['boolean', 'null'])*: Patch memory limits for supported games to improve mod stability. Default: `null`.
+  - **`mem_patch`** *(['boolean', 'null'])*: Patch memory limits for supported games to improve mod stability. Default: `null`.
+  - **`mem_patch_heap_size`** *(['integer', 'null'], format: uint32)*: Override how many megabytes of memory the supported game should allocate
+(with `mem_patch = true`). Minimum: `0`. Default: `null`.
   - **`debug_properties`**: Debug game property overrides. Refer to *[DebugProperties](#DebugProperties)*. Default: `{}`.


### PR DESCRIPTION
Update mimalloc dependency and constrain it to a pre-committed arena to reduce crashes caused by use-after-frees and OOB accesses.

Fixes #742