### PR TITLE
chore(ci): go from `ubuntu-latest` to `ubuntu-26.04`

### DIFF
--- a/.github/actions/setup-windows-toolchain/action.yml
+++ b/.github/actions/setup-windows-toolchain/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt install --install-recommends lld clang-tools llvm wkhtmltopdf nsis
+        sudo apt install --install-recommends lld clang-tools llvm nsis
 
     - name: Cache MSVC SDK
       id: cache-xwin

--- a/.github/actions/setup-windows-toolchain/action.yml
+++ b/.github/actions/setup-windows-toolchain/action.yml
@@ -32,8 +32,8 @@ runs:
             echo "AR_x86_64_pc_windows_msvc=llvm-lib"
             echo "CFLAGS_x86_64_pc_windows_msvc=$CL_FLAGS"
             echo "CXXFLAGS_x86_64_pc_windows_msvc=$CL_FLAGS /EHsc"
-            echo "CC_x86_64_pc_windows_msvc=clang-cl-18"
-            echo "CXX_x86_64_pc_windows_msvc=clang-cl-18"
+            echo "CC_x86_64_pc_windows_msvc=clang-cl-21"
+            echo "CXX_x86_64_pc_windows_msvc=clang-cl-21"
         } >>"$GITHUB_ENV"
 
         cat >~/.cargo/config.toml <<EOF

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   check-release-status:
     name: Check if release needs published
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: write # needed for visibility of draft releases
     steps:
@@ -47,7 +47,7 @@ jobs:
 
   check-spelling:
     name: Check spelling
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -61,7 +61,7 @@ jobs:
       - name: Spell Check Repo
         uses: crate-ci/typos@1a319b54cc9e3b333fed6a5c88ba1a90324da514 # v1.40.1
   check-dead-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       actions: read
@@ -143,7 +143,7 @@ jobs:
     permissions:
       contents: read
     name: Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
-      - uses: ./.github/actions/setup-windows-toolchain
-        if: matrix.os == 'ubuntu-latest'
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           shared-key: me3-build
@@ -71,7 +69,7 @@ jobs:
         if: ${{ !cancelled() }}
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       actions: write
@@ -146,7 +144,7 @@ jobs:
     name: End-to-end tests (Linux)
     needs:
       - build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       actions: read
     steps:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -11,7 +11,7 @@ jobs:
   synchronize-with-crowdin:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   virustotal:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: VirusTotal Scan
         uses: crazy-max/ghaction-virustotal@d34968c958ae283fe976efed637081b9f9dcf74f # v4.2.0
@@ -18,7 +18,7 @@ jobs:
             .exe$
             .zip$
   sentry:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Download release asset (.zip)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   plan:
     name: Build plan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     outputs:
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
       id-token: write
       attestations: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: ${{ needs.plan.outputs.current_version != needs.plan.outputs.next_version }}
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       # Needed for Code scanning upload
       security-events: write


### PR DESCRIPTION
One of our C dependencies (mimalloc) wants Clang 19+, Ubuntu 24.04 supports it, but not as a default (`llvm-defaults` is 18).

https://ubuntu.com/developers/docs/reference/availability/llvm/