### PR TITLE
docs: Add code-signing policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 name: Create release draft
 concurrency:
   group: ${{ github.workflow }}

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,5 @@
+Committers and reviewers:
+- Members team: [Gary Tierney](https://github.com/garyttierney), [Dasaav](https://github.com/Dasaav-dsv), [William Tremblay](https://github.com/tremwil)
+- Approvers: [Gary Tierney](https://github.com/garyttierney), [Dasaav](https://github.com/Dasaav-dsv), [William Tremblay](https://github.com/tremwil)
+
+This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ Discussions Board: [https://github.com/garyttierney/me3/discussions](https://git
 
 We are grateful for the generous support of our sponsors.
 
+### SignPath.io
+
+For the Windows binary, free code signing provided by [SignPath.io](https://about.signpath.io), certificate by [SignPath Foundation](https://signpath.org).
+
+See our [code signing policy](./CODE_SIGNING_POLICY.md)
+
 ### Sentry
 
 <a href="https://sentry.io/" target="_blank"><img src="assets/sponsors/sentry-wordmark-dark-200x60.png" alt="Sentry" /></a>


### PR DESCRIPTION
Satisfies the terms of our SignPath sponsorship: https://signpath.org/terms.html