### PR TITLE
feat: Forward extra arguments to game process

### DIFF
--- a/crates/cli/src/commands/launch.rs
+++ b/crates/cli/src/commands/launch.rs
@@ -173,6 +173,10 @@ pub struct LaunchArgs {
     /// Name of an alternative savefile to use (in the default savefile directory).
     #[arg(long("savefile"), help_heading = "Mod configuration")]
     savefile: Option<String>,
+
+    /// Additional arguments to pass to the game process.
+    #[arg(last = true)]
+    game_args: Vec<String>,
 }
 
 struct LaunchContext {
@@ -482,6 +486,7 @@ pub fn launch(
 
     let _ = std::fs::copy(tmp_log_file_path, &log_file_path);
     let launcher_vars = LauncherVars {
+        argv: args.game_args.clone(),
         exe: game_executable.as_ref().to_path_buf(),
         host_dll: dll_path,
         host_config_path: attach_config_file.path().to_path_buf(),

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -25,6 +25,8 @@ impl EnvVars for TelemetryVars {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LauncherVars {
+    pub argv: Vec<String>,
+
     /// Path to the game EXE that should be launched.
     pub exe: PathBuf,
 

--- a/crates/launcher/src/game.rs
+++ b/crates/launcher/src/game.rs
@@ -42,7 +42,11 @@ pub struct Game {
 
 impl Game {
     #[instrument(skip_all, err)]
-    pub fn launch(game_binary: &Path, game_directory: Option<&Path>) -> LauncherResult<Self> {
+    pub fn launch(
+        game_binary: &Path,
+        args: Vec<String>,
+        game_directory: Option<&Path>,
+    ) -> LauncherResult<Self> {
         let mut command = Command::new(game_binary);
         command.current_dir(
             game_directory
@@ -57,6 +61,7 @@ impl Game {
         info!(trace_id = ?telemetry_vars.trace_id);
         serialize_into_command(telemetry_vars, &mut command);
 
+        command.args(args);
         command.creation_flags(CREATE_SUSPENDED.0);
 
         command

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -42,7 +42,7 @@ fn run(
     }
 
     let game_path = args.exe.parent();
-    let mut game = Game::launch(&args.exe, game_path)?;
+    let mut game = Game::launch(&args.exe, args.argv, game_path)?;
     let request = AttachRequest { config };
 
     match game.attach(&args.host_dll, console_log_writer, file_log_writer, request) {


### PR DESCRIPTION
Any arguments specified in me3 launch after the trailing `--` will be passed to the game during launch.

Fixes #769 