### PR TITLE
fix(host): use mimalloc v3.4.1 which fixes a critical allocation race condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,9 +1599,8 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+version = "0.1.49-mimalloc-v3.4.1"
+source = "git+https://github.com/Dasaav-dsv/mimalloc_rust.git?tag=v0.1.49-mimalloc-v3.4.1#3a2bd7ca51d925c295c5a83c69e3f475ade94d7b"
 dependencies = [
  "cc",
  "cty",

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -23,7 +23,10 @@ dearxan = "0.5.2"
 eyre = { workspace = true, default-features = false, features = ["track-caller"] }
 from-singleton.workspace = true
 libloading = "0.9.0"
-libmimalloc-sys = { version = "0.1.49", features = ["extended", "arena"] }
+libmimalloc-sys = { git = "https://github.com/Dasaav-dsv/mimalloc_rust.git", tag = "v0.1.49-mimalloc-v3.4.1", features = [
+    "extended",
+    "arena",
+] }
 me3-binary-analysis.workspace = true
 me3-env.workspace = true
 me3-ipc.workspace = true


### PR DESCRIPTION
`libmimalloc-sys` has not been updated to this mimalloc version yet, so it temporarily targets a v3.4.1 fork.

Fixes #840