### PR TITLE
fix(windows): Fix "This App can't run on your PC" when a username contains spaces

### DIFF
--- a/installer.nsi
+++ b/installer.nsi
@@ -249,10 +249,10 @@ Section "Main Application" SEC01
     WriteUninstaller "$INSTDIR\uninstall.exe"
 
     !insertmacro APP_ASSOCIATE "me3" "me3.mod-profile" "me3 Mod Profile" \
-      "$INSTDIR\assets\me3.ico" "Open with me3" "$INSTDIR\bin\me3.exe launch -p $\"%1$\""
+      "$INSTDIR\assets\me3.ico" "Open with me3" "\"$INSTDIR\bin\me3.exe\" launch -p $\"%1$\""
 
     !insertmacro APP_ASSOCIATE_ADDVERB "me3.mod-profile" "open-with-diagnostics" "Open with me3 (diagnostics)" \
-      "$INSTDIR\bin\me3.exe launch --diagnostics -p $\"%1$\""
+      "\"$INSTDIR\bin\me3.exe\" launch --diagnostics -p $\"%1$\""
 
     IfFileExists "$INSTDIR\config\me3.toml" file_found file_not_found
 file_found:


### PR DESCRIPTION
Fixes #793

Affected users should reinstall me3 using the Windows installer.

Thanks to https://github.com/Captain02Rex for finding this fix.