### PR TITLE
chore: Release v0.13.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,11 +22,11 @@ body:
       description: What version of our software are you running?
       options:
         - prerelease
+        - v0.13.0
         - v0.12.1
         - v0.12.0
         - v0.11.0
         - v0.10.1
-        - v0.10.0
       default: 1
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to this project will be documented in this file.
 <!-- markdown-link-check-disable -->
 <!-- ignore lint rules that are often triggered by content generated from commits / git-cliff -->
 <!-- markdownlint-disable line-length no-bare-urls ul-style emphasis-style -->
-## me3 - [v0.12.1](https://github.com/garyttierney/me3/releases/v0.12.1) - 2026-07-19
+## me3 - [v0.13.0](https://github.com/garyttierney/me3/releases/v0.13.0) - 2026-08-11
 
 ### 🚀 Features
+
+- [da9abcf](https://github.com/garyttierney/me3/commit/da9abcf86d8f8bfc470801fc8b42d246c40d1fef)  *(host)* Allocate memory at the highest possible address, add dev env vars in [#857](https://github.com/garyttierney/me3/pull/857)
+
+
+
+- [6d381d7](https://github.com/garyttierney/me3/commit/6d381d7342b62cbe9d27c5b3c3f317533618293b)  *(host)* Allow for overriding system properties in [#845](https://github.com/garyttierney/me3/pull/845)
+
+
 
 - [6593712](https://github.com/garyttierney/me3/commit/659371208397101e40ebfec85c8802a7a448f8df)  *(host)* Allow for user provided heap sizes in MB in [#828](https://github.com/garyttierney/me3/pull/828)
 
@@ -66,6 +74,10 @@ All notable changes to this project will be documented in this file.
 
 
 - [4365f37](https://github.com/garyttierney/me3/commit/4365f372e272e8b41a31af63bb47c57457abb144)  *(deps)* Don't eliminate debug tracing events
+
+
+
+- [15a19de](https://github.com/garyttierney/me3/commit/15a19de49312b9b7af4c4efe963b57b17078db4c)  *(host)* Fallback to the global mimalloc heap when an allocation fails (for any reason)
 
 
 
@@ -132,6 +144,10 @@ All notable changes to this project will be documented in this file.
   > to fix Steam Input compatibility and the Steam overlay.
 
 
+- [2cd22c0](https://github.com/garyttierney/me3/commit/2cd22c0503ae9afd3b57b406599b1a0d586cce11) Quote full path to me3 (it may contain spaces) in [#860](https://github.com/garyttierney/me3/pull/860)
+
+
+
 - [e153f4f](https://github.com/garyttierney/me3/commit/e153f4f87f6eb65b454b4deda14e371678ee95f6) Include me3 profiles in taplo config
 
 
@@ -171,6 +187,20 @@ All notable changes to this project will be documented in this file.
   > https://github.com/rust-lang/rust/issues/153438
 
 ### 📚 Documentation
+
+- [529bf68](https://github.com/garyttierney/me3/commit/529bf68637e6c0976b5472925aa0e22a35fcd0bf) Mod-profile simplified chinese in [#850](https://github.com/garyttierney/me3/pull/850)
+
+
+
+- [f2381cf](https://github.com/garyttierney/me3/commit/f2381cf7989348909202f88d72472e3634a0d644) Link to ko-fi in [#847](https://github.com/garyttierney/me3/pull/847)
+
+
+  > Sets up the sponsor button and links it to @Dasaav-dsv's ko-fi.
+
+
+- [8aa3e57](https://github.com/garyttierney/me3/commit/8aa3e57358ebbc2aabb884d7d44414d029ae3f1c) Add policy on using LLMs in [#848](https://github.com/garyttierney/me3/pull/848)
+
+
 
 - [670e0e8](https://github.com/garyttierney/me3/commit/670e0e83a323271e23ba53f890e317d0c47bf1e4) Add code-signing policy in [#835](https://github.com/garyttierney/me3/pull/835)
 
@@ -2946,7 +2976,7 @@ All notable changes to this project will be documented in this file.
 - [c4e6ef5](https://github.com/garyttierney/me3/commit/c4e6ef502776db75d89dbfef6c585b658a28caf4) Initial commit
 
 
-[0.12.1]: https://github.com/garyttierney/me3/compare/v0.11.0..v0.12.1
+[0.13.0]: https://github.com/garyttierney/me3/compare/v0.11.0..v0.13.0
 [0.11.0]: https://github.com/garyttierney/me3/compare/v0.9.0..v0.11.0
 [0.9.0]: https://github.com/garyttierney/me3/compare/v0.8.1..v0.9.0
 [0.8.1]: https://github.com/garyttierney/me3/compare/v0.7.0..v0.8.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "me3-binary-analysis"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "memchr",
  "pelite",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "me3-cli"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "assert_fs",
  "base64",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "me3-env"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "me3-mod-protocol",
  "serde",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "me3-ipc"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "me3-env",
  "me3-launcher-attach-protocol",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "eyre",
  "me3-env",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "me3-launcher-attach-protocol"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "eyre",
  "indexmap",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "base64",
  "closure-ffi",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-assets"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "from-singleton",
  "libc",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-host-types"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "me3-binary-analysis",
  "me3-env",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "me3-mod-protocol"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "expect-test",
  "indexmap",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "me3_telemetry"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "color-eyre",
  "eyre",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.12.1"
+version = "0.13.0"
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/binary-analysis/Cargo.toml
+++ b/crates/binary-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-binary-analysis"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-cli"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-env"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/ipc/Cargo.toml
+++ b/crates/ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-ipc"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher-attach-protocol/Cargo.toml
+++ b/crates/launcher-attach-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher-attach-protocol"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-launcher"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-assets/Cargo.toml
+++ b/crates/mod-host-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-assets"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host-types/Cargo.toml
+++ b/crates/mod-host-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host-types"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-host"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/mod-protocol/Cargo.toml
+++ b/crates/mod-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3-mod-protocol"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "me3_telemetry"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039  # local is non-POSIX
 set -u
 
-INSTALLER_VERSION=v0.12.1
+INSTALLER_VERSION=v0.13.0
 
 need_cmd() {
     if ! check_cmd "$1"; then


### PR DESCRIPTION

## [unreleased]

### 🚀 Features

- [da9abcf](https://github.com/garyttierney/me3/commit/da9abcf86d8f8bfc470801fc8b42d246c40d1fef)  *(host)* Allocate memory at the highest possible address, add dev env vars in [#857](https://github.com/garyttierney/me3/pull/857)



- [6d381d7](https://github.com/garyttierney/me3/commit/6d381d7342b62cbe9d27c5b3c3f317533618293b)  *(host)* Allow for overriding system properties in [#845](https://github.com/garyttierney/me3/pull/845)



### 🐛 Bug Fixes

- [15a19de](https://github.com/garyttierney/me3/commit/15a19de49312b9b7af4c4efe963b57b17078db4c)  *(host)* Fallback to the global mimalloc heap when an allocation fails (for any reason)



- [2cd22c0](https://github.com/garyttierney/me3/commit/2cd22c0503ae9afd3b57b406599b1a0d586cce11) Quote full path to me3 (it may contain spaces) in [#860](https://github.com/garyttierney/me3/pull/860)



### 📚 Documentation

- [529bf68](https://github.com/garyttierney/me3/commit/529bf68637e6c0976b5472925aa0e22a35fcd0bf) Mod-profile simplified chinese in [#850](https://github.com/garyttierney/me3/pull/850)



- [f2381cf](https://github.com/garyttierney/me3/commit/f2381cf7989348909202f88d72472e3634a0d644) Link to ko-fi in [#847](https://github.com/garyttierney/me3/pull/847)


  > Sets up the sponsor button and links it to @Dasaav-dsv's ko-fi.


- [8aa3e57](https://github.com/garyttierney/me3/commit/8aa3e57358ebbc2aabb884d7d44414d029ae3f1c) Add policy on using LLMs in [#848](https://github.com/garyttierney/me3/pull/848)