### PR TITLE
fix(deps): bump dearxan to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,9 +328,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "dearxan"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e86553ef0bf14823d391defe07b852c9a43860898cbff00c361904f43a76a12"
+checksum = "df9ca30e38c5e599272283f9afa1bfbc3b5ed2dbf7f3dea72baba352a4a7b72b"
 dependencies = [
  "atomic-wait",
  "bitfield-struct",

--- a/crates/mod-host/Cargo.toml
+++ b/crates/mod-host/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 indexmap.workspace = true
 closure-ffi = { version = "5.0", features = ["coverage", "std", "tuple_trait"] }
 color-eyre.workspace = true
-dearxan = "0.5.2"
+dearxan = "0.5.5"
 eyre = { workspace = true, default-features = false, features = ["track-caller"] }
 from-singleton.workspace = true
 libloading = "0.9.0"


### PR DESCRIPTION
Update to the latest dearxan which correctly handles the encrypted Arxan stubs present in Elden Ring and Nightreign.